### PR TITLE
Bug when parsing the query string with POST requests having content

### DIFF
--- a/src/java/winstone/WinstoneRequest.java
+++ b/src/java/winstone/WinstoneRequest.java
@@ -1031,7 +1031,9 @@ public class WinstoneRequest implements HttpServletRequest {
                 Logger.log(Logger.WARNING, Launcher.RESOURCES, "WinstoneRequest.BothMethods");
             }
         }
-        this.parsedParameters = new Boolean(false);
+        if (method.equals(METHOD_POST) && POST_PARAMETERS.equals(contentType)) {
+            this.parsedParameters = new Boolean(false);
+        }
         return this.inputData;
     }
 


### PR DESCRIPTION
Winstone does not parse the query string if the POST request has any content. This would be the correct behavior for forms, but not for normal requests, specially when we want to send POST requests for executing tasks, such as createItem.

While using createItem, i have to send a POST request, with an XML file containing the job XML. This patch fixes the bug that caused Winstone to ignore the request, spitting out an 500 error. 

Originally by Roland Huss: http://sourceforge.net/tracker/?func=detail&aid=3402077&group_id=98922&atid=622497
