### PR TITLE
Add stub methods and update enforcer rule to support compilation with Java 7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
                   <configuration>
                     <rules>
                       <requireJavaVersion>
-                        <version>(1.6,1.7)</version>
+                        <version>1.6,</version>
                       </requireJavaVersion>
                     </rules>
                   </configuration>

--- a/src/java/winstone/jndi/resourceFactories/WinstoneConnection.java
+++ b/src/java/winstone/jndi/resourceFactories/WinstoneConnection.java
@@ -24,6 +24,7 @@ import java.sql.Statement;
 import java.sql.Struct;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.Executor;
 
 import winstone.Logger;
 
@@ -304,5 +305,26 @@ public class WinstoneConnection implements Connection {
 	public void setTypeMap(Map<String, Class<?>> map) throws SQLException {
 		// TODO Auto-generated method stub
 		
+	}
+
+	public void abort(Executor executor) throws SQLException {
+		throw new SQLFeatureNotSupportedException();
+	}
+
+	public int getNetworkTimeout() throws SQLException {
+		throw new SQLFeatureNotSupportedException();
+	}
+
+	public String getSchema() throws SQLException {
+		throw new SQLFeatureNotSupportedException();
+	}
+
+	public void setNetworkTimeout(Executor executor, int milliseconds)
+			throws SQLException {
+		throw new SQLFeatureNotSupportedException();
+	}
+
+	public void setSchema(String schema) throws SQLException {
+		throw new SQLFeatureNotSupportedException();		
 	}
 }

--- a/src/java/winstone/jndi/resourceFactories/WinstoneDataSource.java
+++ b/src/java/winstone/jndi/resourceFactories/WinstoneDataSource.java
@@ -11,6 +11,7 @@ import java.sql.Connection;
 import java.sql.Driver;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -479,5 +480,10 @@ public class WinstoneDataSource implements DataSource, Runnable {
 	public boolean isWrapperFor(Class<?> iface) throws SQLException {
 		// TODO Auto-generated method stub
 		return false;
+	}
+
+	public java.util.logging.Logger getParentLogger()
+			throws SQLFeatureNotSupportedException {
+		throw new SQLFeatureNotSupportedException();
 	}
 }


### PR DESCRIPTION
Ubuntu/Debian are transitioning to Java 7 as default (and maybe dropping Java 6).

As a result need to make all code compile with Java 7 - stub methods added to jenkins-winstone.
