### PR TITLE
Make date format of cookie "Expires" field more unequivocal (YY-> YYYY)

### DIFF
--- a/src/java/winstone/WinstoneResponse.java
+++ b/src/java/winstone/WinstoneResponse.java
@@ -6,25 +6,16 @@
  */
 package winstone;
 
+import javax.servlet.ServletOutputStream;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.UnsupportedEncodingException;
 import java.io.Writer;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
-import java.util.StringTokenizer;
-import java.util.TimeZone;
-
-import javax.servlet.ServletOutputStream;
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletResponse;
+import java.util.*;
 
 /**
  * Response for servlet
@@ -37,7 +28,7 @@ public class WinstoneResponse implements HttpServletResponse {
     private static final DateFormat HTTP_DF = new SimpleDateFormat(
             "EEE, dd MMM yyyy HH:mm:ss z", Locale.US);
     private static final DateFormat VERSION0_DF = new SimpleDateFormat(
-            "EEE, dd-MMM-yy HH:mm:ss z", Locale.US);
+            "EEE, dd-MMM-yyyy HH:mm:ss z", Locale.US);
     static {
         HTTP_DF.setTimeZone(TimeZone.getTimeZone("GMT"));
         VERSION0_DF.setTimeZone(TimeZone.getTimeZone("GMT"));

--- a/src/test/winstone/WinstoneResponseTest.java
+++ b/src/test/winstone/WinstoneResponseTest.java
@@ -1,0 +1,22 @@
+package winstone;
+
+import org.junit.Test;
+
+import javax.servlet.http.Cookie;
+
+import static org.junit.Assert.assertTrue;
+
+public class WinstoneResponseTest {
+
+    @SuppressWarnings("unchecked")
+    @Test public void testCookieExpires() throws Exception {
+        WinstoneResponse response = new WinstoneResponse();
+
+        Cookie cookie = new Cookie("testcookie", "cookievalue");
+        cookie.setMaxAge(1000);
+        String cookieAsString = response.writeCookie(cookie);
+
+        assertTrue("expires date format", cookieAsString.matches(".*Expires=\\w{3}, \\d{1,2}-\\w{3}-\\d{4} \\d{1,2}:\\d{1,2}:\\d{1,2} GMT.*"));
+    }
+
+}


### PR DESCRIPTION
This fix is an attempt to resolve [JENKINS-9258](https://issues.jenkins-ci.org/browse/JENKINS-9258). It seems like winstone creates Expires-values for cookies that contain a two-digit year field. While this is valid according to [RFC 6265](http://tools.ietf.org/html/rfc6265#section-5.1.1) it is also highly ambiguous. So this change makes the year a four-digit field. This should fix problems with cookies being silently dropped.
