### PR TITLE
Exclude SSLv2 and SSLv2Hello.

### DIFF
--- a/src/java/winstone/HttpsConnectorFactory.java
+++ b/src/java/winstone/HttpsConnectorFactory.java
@@ -221,7 +221,7 @@ public class HttpsConnectorFactory implements ConnectorFactory {
             ssl.setKeyManagerPassword(privateKeyPassword);
             ssl.setSslKeyManagerFactoryAlgorithm(Option.HTTPS_KEY_MANAGER_TYPE.get(args));
             ssl.setCertAlias(Option.HTTPS_CERTIFICATE_ALIAS.get(args));
-            ssl.setExcludeProtocols("SSLv3");
+            ssl.setExcludeProtocols("SSLv3", "SSLv2", "SSLv2Hello");
 
             /**
              * If true, request the client certificate ala "SSLVerifyClient require" Apache directive.


### PR DESCRIPTION
Add exclude rules for SSLv2 and SSLv2Hello.

``` cmd
java -jar target/winstone-2.8-SNAPSHOT.jar --warfile=/home/schristou/Downloads/jenkins.war --httpsPort=4430
.......
INFO: Enabled Protocols [TLSv1, TLSv1.1, TLSv1.2] of [SSLv2Hello, SSLv3, TLSv1, TLSv1.1, TLSv1.2]
```
