### PR TITLE
[FIXED JENKINS-20327][FIXED JENKINS-23221][FIXED JENKINS-24804][FIXED JE...

### DIFF
--- a/src/java/winstone/Launcher.java
+++ b/src/java/winstone/Launcher.java
@@ -138,6 +138,8 @@ public class Launcher implements Runnable {
             if (maxParameterCount>0) {
                 server.setAttribute("org.eclipse.jetty.server.Request.maxFormKeys",maxParameterCount);
             }
+            server.setAttribute("org.eclipse.jetty.server.Request.maxFormContentSize",
+                    Option.REQUEST_FORM_CONTENT_SIZE.get(args));
 
             // Open the web apps
             this.hostGroup = new HostGroup(server, commonLibCL,

--- a/src/java/winstone/cmdline/Option.java
+++ b/src/java/winstone/cmdline/Option.java
@@ -112,6 +112,7 @@ public class Option<T> {
     public static final OInt SESSION_TIMEOUT=integer("sessionTimeout",-1);
     public static final OInt REQUEST_HEADER_SIZE=integer("requestHeaderSize",8192); // default for jetty 8
     public static final OInt REQUEST_BUFFER_SIZE=integer("requestBufferSize",16384); // default for jetty 8
+    public static final OInt REQUEST_FORM_CONTENT_SIZE=integer("requestFormContentSize",-1); // no limit (compat with old winstone)
     public static final OBoolean HELP=bool("help",false);
 
     public static final OClass REALM_CLASS_NAME=clazz("realmClassName", ArgumentsRealm.class);


### PR DESCRIPTION
...NKINS-21064] java.lang.IllegalStateException: Form too large

The default should be `-1`, i.e. no limit, for maximum compatibility with the original winstone