### PR TITLE
Multi Webapp support fixed

### DIFF
--- a/src/java/winstone/HostConfiguration.java
+++ b/src/java/winstone/HostConfiguration.java
@@ -333,7 +333,6 @@ public class HostConfiguration {
                         if (!this.webapps.containsKey(prefix)) {
                             try {
                                 WebAppContext context = create(aChildren, prefix);
-                                context.start();
                                 webApps.addHandler(configureAccessLog(context,childName));
                                 Logger.log(Logger.INFO, Launcher.RESOURCES, "HostConfig.DeployingWebapp", childName);
                             } catch (Throwable err) {
@@ -351,7 +350,6 @@ public class HostConfiguration {
                         try {
                             WebAppContext context = create(
                                     getWebRoot(new File(webappsDir, outputName), aChildren), prefix);
-                            context.start();
                             webApps.addHandler(configureAccessLog(context,outputName));
                             Logger.log(Logger.INFO, Launcher.RESOURCES, "HostConfig.DeployingWebapp", childName);
                         } catch (Throwable err) {


### PR DESCRIPTION
It seems that context must not be started upon creation in HostConfiguration (which is already the case for single webapp). Removing those two lines seems to fix multi webapp support, which otherwise is broken with this error message:

```
Sep 10, 2015 7:41:04 PM org.eclipse.jetty.util.log.JavaUtilLog warn
WARNING: FAILED org.eclipse.jetty.server.session.HashSessionManager@39dd3812: java.lang.NullPointerException
java.lang.NullPointerException
        at org.eclipse.jetty.server.session.AbstractSessionManager.doStart(AbstractSessionManager.java:239)
        at org.eclipse.jetty.server.session.HashSessionManager.doStart(HashSessionManager.java:92)
        at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:64)
        at org.eclipse.jetty.server.session.SessionHandler.doStart(SessionHandler.java:123)
        at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:64)
        at org.eclipse.jetty.server.handler.HandlerWrapper.doStart(HandlerWrapper.java:95)
        at org.eclipse.jetty.server.handler.ScopedHandler.doStart(ScopedHandler.java:115)
        at org.eclipse.jetty.server.handler.ContextHandler.startContext(ContextHandler.java:763)
        at org.eclipse.jetty.servlet.ServletContextHandler.startContext(ServletContextHandler.java:249)
        at org.eclipse.jetty.webapp.WebAppContext.startContext(WebAppContext.java:1242)
        at org.eclipse.jetty.server.handler.ContextHandler.doStart(ContextHandler.java:717)
        at org.eclipse.jetty.webapp.WebAppContext.doStart(WebAppContext.java:494)
        at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:64)
        at winstone.HostConfiguration.initMultiWebappDir(HostConfiguration.java:336)
        at winstone.HostConfiguration.<init>(HostConfiguration.java:87)
        at winstone.HostGroup.initHost(HostGroup.java:66)
        at winstone.HostGroup.<init>(HostGroup.java:45)
        at winstone.Launcher.<init>(Launcher.java:143)
        at winstone.Launcher.main(Launcher.java:354)
```