### PR TITLE
[JENKINS-23378] Jetty9 upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.jenkins-ci</groupId>
   <artifactId>winstone</artifactId>
-  <version>2.10-SNAPSHOT</version>
+  <version>3.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Winstone</name>

--- a/pom.xml
+++ b/pom.xml
@@ -221,25 +221,27 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-servlet</artifactId>
-      <version>8.1.13.v20130916</version>
+      <version>9.2.15.v20160210</version>
     </dependency>
 
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-webapp</artifactId>
-      <version>8.1.13.v20130916</version>
+      <version>9.2.15.v20160210</version>
     </dependency>
 
+    <!--  See https://github.com/eclipse/jetty.project/issues/134
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-ajp</artifactId>
-      <version>8.1.13.v20130916</version>
+      <version>9.2.15.v20160210</version>
     </dependency>
+    -->
 
     <dependency>
       <groupId>org.eclipse.jetty.spdy</groupId>
-      <artifactId>spdy-jetty-http</artifactId>
-      <version>8.1.13.v20130916</version>
+      <artifactId>spdy-http-server</artifactId>
+      <version>9.2.15.v20160210</version>
     </dependency>
 
     <dependency>

--- a/src/java/winstone/Ajp13ConnectorFactory.java
+++ b/src/java/winstone/Ajp13ConnectorFactory.java
@@ -6,9 +6,7 @@
  */
 package winstone;
 
-import org.eclipse.jetty.ajp.Ajp13SocketConnector;
 import org.eclipse.jetty.server.Server;
-import winstone.ConnectorFactory;
 import winstone.cmdline.Option;
 
 import java.io.IOException;
@@ -30,6 +28,9 @@ public class Ajp13ConnectorFactory implements ConnectorFactory {
             return false;
         }
 
+        throw new UnsupportedOperationException();
+
+        /* Jetty9 has no AJP support
         Ajp13SocketConnector connector = new Ajp13SocketConnector();
         connector.setPort(listenPort);
         connector.setHost(listenAddress);
@@ -38,5 +39,6 @@ public class Ajp13ConnectorFactory implements ConnectorFactory {
 
         server.addConnector(connector);
         return true;
+        */
     }
 }

--- a/src/java/winstone/Launcher.java
+++ b/src/java/winstone/Launcher.java
@@ -62,8 +62,8 @@ public class Launcher implements Runnable {
     private ExecutorService threadPool;
     private Map args;
 
-    public final Server server = new Server();
-    
+    public final Server server;
+
     /**
      * Constructor - initialises the web app, object pools, control port and the
      * available protocol listeners.
@@ -133,6 +133,7 @@ public class Launcher implements Runnable {
                     commonLibCLPaths.toString());
 
             this.threadPool = createThreadPool();
+            this.server = new Server(new ExecutorThreadPool(threadPool));
 
             int maxParameterCount = Option.MAX_PARAM_COUNT.get(args);
             if (maxParameterCount>0) {
@@ -149,8 +150,6 @@ public class Launcher implements Runnable {
             spawnListener(HTTP_LISTENER_CLASS);
             spawnListener(AJP_LISTENER_CLASS);
             spawnListener(HTTPS_LISTENER_CLASS);
-
-            server.setThreadPool(new ExecutorThreadPool(threadPool));
 
             try {
                 server.start();

--- a/src/java/winstone/cmdline/Option.java
+++ b/src/java/winstone/cmdline/Option.java
@@ -111,6 +111,10 @@ public class Option<T> {
     public static final OBoolean USAGE=bool("usage",false);
     public static final OInt SESSION_TIMEOUT=integer("sessionTimeout",-1);
     public static final OInt REQUEST_HEADER_SIZE=integer("requestHeaderSize",8192); // default for jetty 8
+    /**
+     * @deprecated
+     *      Doesn't appear to have the corresponding property in Jetty9
+     */
     public static final OInt REQUEST_BUFFER_SIZE=integer("requestBufferSize",16384); // default for jetty 8
     public static final OInt REQUEST_FORM_CONTENT_SIZE=integer("requestFormContentSize",-1); // no limit (compat with old winstone)
     public static final OBoolean HELP=bool("help",false);

--- a/src/test/winstone/Ajp13ConnectorFactoryTest.java
+++ b/src/test/winstone/Ajp13ConnectorFactoryTest.java
@@ -16,6 +16,7 @@
  */
 package winstone;
 
+import org.junit.Ignore;
 import org.junit.Test;
 import org.kohsuke.ajp.client.SimpleAjpClient;
 import org.kohsuke.ajp.client.TesterAjpMessage;
@@ -27,7 +28,7 @@ import java.util.Map;
  * @author Kohsuke Kawaguchi
  */
 public class Ajp13ConnectorFactoryTest extends AbstractWinstoneTest {
-    @Test
+    @Test @Ignore("Jetty9 doesn't support AJP yet")
     public void ajp() throws Exception {
         Map<String,String> args = new HashMap<String,String>();
         args.put("warfile", "target/test-classes/test.war");


### PR DESCRIPTION
As a part of upgrading Jenkins to servlet 3.1, we need Winstone to support servlet 3.1, which this PR does by pulling in Jetty 9.2, which is the latest version of Jetty that runs on Java7.

Notable incompatibilities include:
* Lack of AJP support ([link](https://github.com/eclipse/jetty.project/issues/134))
* requestBufferSize setting in Jetty8 appears to have no counterpart

This PR is to let others comment on the changes thus far, find those missing features from somewhere, and try it out on Jenkins. Once we decide to drop those functionalities, we need a follow-up change to clean up the help screen, really remove AJP related code, etc.