### PR TITLE
update ci build to use JDK8

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,7 @@ for (int i = 0; i < platforms.size(); ++i) {
 
                 stage('Build') {
                     withEnv([
-                        "JAVA_HOME=${tool 'jdk7'}",
+                        "JAVA_HOME=${tool 'jdk8'}",
                         "PATH+MVN=${tool 'mvn'}/bin",
                         'PATH+JDK=$JAVA_HOME/bin',
                     ]) {


### PR DESCRIPTION
Updates the Jenkinsfile to use JDK8 for the builds.

@reviewbybees   Blocked by #23 