### PR TITLE
[FIXED JENKINS-42159] If startup fails, exit the process.

### DIFF
--- a/src/java/winstone/HostConfiguration.java
+++ b/src/java/winstone/HostConfiguration.java
@@ -180,6 +180,7 @@ public class HostConfiguration {
             }
         };
         wac.getSecurityHandler().setLoginService(loginService);
+        wac.setThrowUnavailableOnStartupException(true);    // if boot fails, abort the process instead of letting empty Jetty run
         wac.setMimeTypes(mimeTypes);
         SessionManager sm = wac.getSessionHandler().getSessionManager();
         sm.setSessionTrackingModes(Collections.singleton(SessionTrackingMode.COOKIE)); // disable URL-rewrite based session tracking, which leaks session ID. See JENKINS-22358

--- a/src/java/winstone/Launcher.java
+++ b/src/java/winstone/Launcher.java
@@ -352,6 +352,7 @@ public class Launcher implements Runnable {
             new Launcher(args);
         } catch (Throwable err) {
             Logger.log(Logger.ERROR, RESOURCES, "Launcher.ContainerStartupError", err);
+            System.exit(1);
         }
     }
     


### PR DESCRIPTION
As it stands right now, empty Jetty keeps running and makes it difficult
to detect catastrophic boot error.

The code change makes any exception thrown from ServletContextListener a
fatal problem.

https://issues.jenkins-ci.org/browse/JENKINS-42159