### PR TITLE
[JENKINS-49596] - Increase timeout to 30 min, Noting 4.1.1 and adding it to documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,17 @@ Changelog
 
 ##4.2
 
+Release date: Coming soon
+
 * Update Jetty from `9.4.5.v20170502` to `9.4.8.v20171121` [CHANGELOG](https://github.com/eclipse/jetty.project/releases/tag/jetty-9.4.8.v20171121)
-* User session memory leak. [JENKINS-49596](https://issues.jenkins-ci.org/browse/JENKINS-49596)
+
+## 4.1.1
+
+Release date: Feb 22, 2017
+
+* [JENKINS-49596](https://issues.jenkins-ci.org/browse/JENKINS-49596) -
+Prevent User session memory leak by setting the default idle session eviction timeout to 3 minutes. 
+* Allow configuring the session eviction timeout via the `-sessionEviction` command-line option.
 
 ##4.1
 

--- a/README.md
+++ b/README.md
@@ -90,8 +90,9 @@ To run different web applications for diffent virtual hosts:
 
        --useJasper              = enable jasper JSP handling (true/false). Default is false
        --sessionTimeout         = set the http session timeout value in minutes. Default to what webapp specifies, and then to 60 minutes
-       --sessionEviction        = Set the session evition timeout for idle sessions. Default value is 180s.
-                                  (-1 is never evict; 0 is evict-on-exit; and any other positive value is the time in seconds that a session can be idle before it can be evicted)
+       --sessionEviction        = Set the session evition timeout for idle sessions. Default value is 30min.
+                                  (-1 is never evict; 0 is evict-on-exit; and any other positive value is the time 
+                                  in seconds that a session can be idle before it can be evicted)
        --mimeTypes=ARG          = define additional MIME type mappings. ARG would be EXT=MIMETYPE:EXT=MIMETYPE:...
                                   (e.g., xls=application/vnd.ms-excel:wmf=application/x-msmetafile)
        --maxParamCount=N        = set the max number of parameters allowed in a form submission to protect

--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ To run different web applications for diffent virtual hosts:
 
        --useJasper              = enable jasper JSP handling (true/false). Default is false
        --sessionTimeout         = set the http session timeout value in minutes. Default to what webapp specifies, and then to 60 minutes
+       --sessionEviction        = Set the session evition timeout for idle sessions. Default value is 180s.
+                                  (-1 is never evict; 0 is evict-on-exit; and any other positive value is the time in seconds that a session can be idle before it can be evicted)
        --mimeTypes=ARG          = define additional MIME type mappings. ARG would be EXT=MIMETYPE:EXT=MIMETYPE:...
                                   (e.g., xls=application/vnd.ms-excel:wmf=application/x-msmetafile)
        --maxParamCount=N        = set the max number of parameters allowed in a form submission to protect

--- a/src/java/winstone/cmdline/Option.java
+++ b/src/java/winstone/cmdline/Option.java
@@ -97,7 +97,7 @@ public class Option<T> {
     public static final OInt MAX_PARAM_COUNT=integer("maxParamCount",-1);
     public static final OBoolean USAGE=bool("usage",false);
     public static final OInt SESSION_TIMEOUT=integer("sessionTimeout",-1);
-    public static final OInt SESSION_EVICTION=integer("sessionEviction",180);
+    public static final OInt SESSION_EVICTION=integer("sessionEviction",1800);
     public static final OInt REQUEST_HEADER_SIZE=integer("requestHeaderSize",8192); // default for jetty 9
     public static final OInt REQUEST_FORM_CONTENT_SIZE=integer("requestFormContentSize",-1); // no limit (compat with old winstone)
     public static final OBoolean HELP=bool("help",false);


### PR DESCRIPTION
@olamy @dwnusbaum I have released 4.1.1 for testing on the Master's side. Actually it should have been a staged timestamped snapshot, but it was too late when I realised that. In the worst case we can mark release as burned one

For now I did some polishing: https://issues.jenkins-ci.org/browse/JENKINS-49596

@reviewbybees 
