### PR TITLE
Update Jetty to 9.4.12.v20180830

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
   <description>Winstone is a command line wrapper around Jetty</description>
 
   <properties>
-    <jetty.version>9.4.11.v20180605</jetty.version>
+    <jetty.version>9.4.12.v20180830</jetty.version>
     <alpn.api.version>1.1.3.v20160715</alpn.api.version>
     <java.level>8</java.level>
     <!-- TODO: remove once FindBugs issues are fixed. 57 so far -->


### PR DESCRIPTION
https://github.com/eclipse/jetty.project/releases/tag/jetty-9.4.12.v20180830
It contains some fixes towards Java 9+, it makes sense to pick-up the update

@olamy @jenkinsci/sig-platform 
