### PR TITLE
JENKINS-56591 cipher exclusion configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 ===
 
+## 5.2
+
+Release date: ?
+
+* [JENKINS-56591](https://issues.jenkins-ci.org/browse/JENKINS-56591) cipher exclusion configurable
+
 ## 5.1
 
 Release date: Oct 06, 2018

--- a/README.md
+++ b/README.md
@@ -51,8 +51,10 @@ To run different web applications for diffent virtual hosts:
 
 
 ## Command-line options
-    Usage: java winstone.Launcher [--option=value] [--option=value] [etc]
 
+    Winstone Servlet Engine v4.0, (c) 2003-2006 Rick Knowles
+    Usage: java winstone.jar [--option=value] [--option=value] [etc]
+    
     Required options: either --webroot OR --warfile OR --webappsDir OR --hostsDir
        --webroot                = set document root folder.
        --warfile                = set location of warfile to extract from.
@@ -63,12 +65,13 @@ To run different web applications for diffent virtual hosts:
        --config                 = load configuration properties from here. Default is ./winstone.properties
        --prefix                 = add this prefix to all URLs (eg http://localhost:8080/prefix/resource). Default is none
        --commonLibFolder        = folder for additional jar files. Default is ./lib
+    
        --extraLibFolder         = folder for additional jar files to add to Jetty classloader
-
+    
        --logThrowingLineNo      = show the line no that logged the message (slow). Default is false
        --logThrowingThread      = show the thread that logged the message. Default is false
        --debug                  = set the level of debug msgs (1-9). Default is 5 (INFO level)
-
+    
        --httpPort               = set the http listening port. -1 to disable, Default is 8080
        --httpListenAddress      = set the http listening address. Default is all interfaces
        --httpKeepAliveTimeout   = how long idle HTTP keep-alive connections are kept around (in ms; default 5000)?
@@ -81,39 +84,45 @@ To run different web applications for diffent virtual hosts:
        --httpsPrivateKey        = this switch with --httpsCertificate can be used to run HTTPS with OpenSSL secret key
          / --httpsCertificate     file and the corresponding certificate file
        --http2Port              = set the http2 listening port. -1 to disable, Default is disabled
-       --http2ListenAddress     = set the http2 listening address. Default is all interfaces         
+       --http2ListenAddress     = set the http2 listening address. Default is all interfaces
+       --excludeCipherSuites    = set the ciphers to exclude (comma separated, use blank quote " " to exclude none) (default is 
+                               // Exclude weak / insecure ciphers 
+                               "^.*_(MD5|SHA|SHA1)$", 
+                               // Exclude ciphers that don't support forward secrecy 
+                               "^TLS_RSA_.*$", 
+                               // The following exclusions are present to cleanup known bad cipher 
+                               // suites that may be accidentally included via include patterns. 
+                               // The default enabled cipher list in Java will not include these 
+                               // (but they are available in the supported list). 
+                               "^SSL_.*$", 
+                               "^.*_NULL_.*$", 
+                               "^.*_anon_.*$" 
        --controlPort            = set the shutdown/control port. -1 to disable, Default disabled
-       
-       --requestHeaderSize      = sets the size of the buffer for request headers. Default is 8K.
-
+    
        --useJasper              = enable jasper JSP handling (true/false). Default is false
        --sessionTimeout         = set the http session timeout value in minutes. Default to what webapp specifies, and then to 60 minutes
-       --sessionEviction        = Set the session eviction timeout for idle sessions. Default value is 30min.
-                                  (-1 is never evict; 0 is evict-on-exit; and any other positive value is the time 
-                                  in seconds that a session can be idle before it can be evicted)
+       --sessionEviction        = set the session eviction timeout for idle sessions in seconds. Default value is 180. -1 never evict, 0 evict on exit
        --mimeTypes=ARG          = define additional MIME type mappings. ARG would be EXT=MIMETYPE:EXT=MIMETYPE:...
                                   (e.g., xls=application/vnd.ms-excel:wmf=application/x-msmetafile)
        --maxParamCount=N        = set the max number of parameters allowed in a form submission to protect
                                   against hash DoS attack (oCERT #2011-003). Default is 10000.
-       --useJmx                 = Enable Jetty JMX    
-       --qtpMaxThreadsCount     = max threads number when using Jetty Queued Thread Pool                           
+       --useJmx                 = Enable Jetty Jmx
+       --qtpMaxThreadsCount     = max threads number when using Jetty Queued Thread Pool
        --jettyAcceptorsCount    = Jetty Acceptors number
        --jettySelectorsCount    = Jetty Selectors number
        --usage / --help         = show this message
-
-    Security options:
+     Security options:
        --realmClassName               = Set the realm class to use for user authentication. Defaults to ArgumentsRealm class
-
+    
        --argumentsRealm.passwd.<user> = Password for user <user>. Only valid for the ArgumentsRealm realm class
        --argumentsRealm.roles.<user>  = Roles for user <user> (comma separated). Only valid for the ArgumentsRealm realm class
-
+    
        --fileRealm.configFile         = File containing users/passwds/roles. Only valid for the FileRealm realm class
-
-    Access logging:
+    
+     Access logging:
        --accessLoggerClassName        = Set the access logger class to use for user authentication. Defaults to disabled
        --simpleAccessLogger.format    = The log format to use. Supports combined/common/resin/custom (SimpleAccessLogger only)
        --simpleAccessLogger.file      = The location pattern for the log file(SimpleAccessLogger only)
-
 
 ## Configuration file
 You don't really need a config file, but sometimes it's handy to

--- a/pom.xml
+++ b/pom.xml
@@ -214,40 +214,44 @@
 
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-server</artifactId>
+      <version>${jetty.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-util</artifactId>
+      <version>${jetty.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-servlet</artifactId>
       <version>${jetty.version}</version>
     </dependency>
-
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-webapp</artifactId>
       <version>${jetty.version}</version>
     </dependency>
-
     <dependency>
       <groupId>org.eclipse.jetty.http2</groupId>
       <artifactId>http2-server</artifactId>
       <version>${jetty.version}</version>
     </dependency>
-
     <dependency>
       <groupId>org.eclipse.jetty.http2</groupId>
       <artifactId>http2-hpack</artifactId>
       <version>${jetty.version}</version>
     </dependency>
-
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-alpn-server</artifactId>
       <version>${jetty.version}</version>
     </dependency>
-
     <dependency>
       <groupId>org.eclipse.jetty.alpn</groupId>
       <artifactId>alpn-api</artifactId>
       <version>${alpn.api.version}</version>
     </dependency>
-
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-jmx</artifactId>

--- a/src/main/java/winstone/AbstractSecuredConnectorFactory.java
+++ b/src/main/java/winstone/AbstractSecuredConnectorFactory.java
@@ -32,6 +32,7 @@ import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.security.spec.RSAPrivateKeySpec;
 import java.text.MessageFormat;
+import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.Map;
 import java.util.logging.Level;
@@ -172,7 +173,7 @@ public abstract class AbstractSecuredConnectorFactory implements ConnectorFactor
             // There are many legacy setups in which the KeyStore password and the
             // key password are identical and people will not even be aware that these
             // are two different things
-            // Therefore if no httpsPrivateKeyPassword is explicitely set we try to
+            // Therefore if no httpsPrivateKeyPassword is explicitly set we try to
             // use the KeyStore password also for the key password not to break
             // backward compatibility
             // Otherwise the following code will completely break the startup of
@@ -197,14 +198,20 @@ public abstract class AbstractSecuredConnectorFactory implements ConnectorFactor
             }
 
             SslContextFactory ssl = new SslContextFactory();
-
             ssl.setKeyStore(keystore);
             ssl.setKeyStorePassword(keystorePassword);
             ssl.setKeyManagerPassword(privateKeyPassword);
             ssl.setKeyManagerFactoryAlgorithm(Option.HTTPS_KEY_MANAGER_TYPE.get(args));
             ssl.setCertAlias(Option.HTTPS_CERTIFICATE_ALIAS.get(args));
             ssl.setExcludeProtocols("SSLv3", "SSLv2", "SSLv2Hello");
-
+            String excludeCiphers = Option.HTTPS_EXCLUDE_CIPHER_SUITES.get(args);
+            if(excludeCiphers!=null&&excludeCiphers.length()>0) {
+                String[] cipherSuites = excludeCiphers.split(",");
+                ssl.setExcludeCipherSuites(cipherSuites);
+            }
+            Logger.log( Logger.INFO, SSL_RESOURCES, //
+                        "HttpsListener.ExcludeCiphers", //
+                        Arrays.asList(ssl.getExcludeCipherSuites()));
 
             /**
              * If true, request the client certificate ala "SSLVerifyClient require" Apache directive.

--- a/src/main/java/winstone/cmdline/Option.java
+++ b/src/main/java/winstone/cmdline/Option.java
@@ -70,6 +70,7 @@ public class Option<T> {
     public static final OFile HTTPS_CERTIFICATE=file("httpsCertificate");
     public static final OString HTTPS_CERTIFICATE_ALIAS=string("httpsCertificateAlias");
     public static final OFile HTTPS_PRIVATE_KEY=file("httpsPrivateKey");
+    public static final OString HTTPS_EXCLUDE_CIPHER_SUITES=string("excludeCipherSuites");
 
     public static final OInt AJP13_PORT=integer("ajp13"+_PORT,-1);
     public static final OString AJP13_LISTEN_ADDRESS=string("ajp13"+_LISTEN_ADDRESS);

--- a/src/main/resources/winstone/LocalStrings.properties
+++ b/src/main/resources/winstone/LocalStrings.properties
@@ -98,6 +98,18 @@ Launcher.UsageInstructions.Options=\
 \     / --httpsCertificate     file and the corresponding certificate file\n\
 \   --http2Port              = set the http2 listening port. -1 to disable, Default is disabled\n\
 \   --http2ListenAddress     = set the http2 listening address. Default is all interfaces\n\
+\   --excludeCipherSuites    = set the ciphers to exclude (comma separated, use blank quote " " to exclude none) (default is\n\
+\                           // Exclude weak / insecure ciphers \n\
+\                           "^.*_(MD5|SHA|SHA1)$", \n\
+\                           // Exclude ciphers that don't support forward secrecy \n\
+\                           "^TLS_RSA_.*$", \n\
+\                           // The following exclusions are present to cleanup known bad cipher \n\
+\                           // suites that may be accidentally included via include patterns. \n\
+\                           // The default enabled cipher list in Java will not include these \n\
+\                           // (but they are available in the supported list). \n\
+\                           "^SSL_.*$", \n\
+\                           "^.*_NULL_.*$", \n\
+\                           "^.*_anon_.*$" \n\
 \   --controlPort            = set the shutdown/control port. -1 to disable, Default disabled\n\n\
 \   --useJasper              = enable jasper JSP handling (true/false). Default is false\n\
 \   --sessionTimeout         = set the http session timeout value in minutes. Default to what webapp specifies, and then to 60 minutes\n\
@@ -109,14 +121,14 @@ Launcher.UsageInstructions.Options=\
 \   --useJmx                 = Enable Jetty Jmx\n\
 \   --qtpMaxThreadsCount     = max threads number when using Jetty Queued Thread Pool\n\
 \   --jettyAcceptorsCount    = Jetty Acceptors number\n\
-\   --jettySelectorsCount    = Jetty Selectors number\n\      
-\   --usage / --help         = show this message\n\n\
-Security options:\n\
+\   --jettySelectorsCount    = Jetty Selectors number\n\
+\   --usage / --help         = show this message\n\
+\ Security options:\n\
 \   --realmClassName               = Set the realm class to use for user authentication. Defaults to ArgumentsRealm class\n\n\
 \   --argumentsRealm.passwd.<user> = Password for user <user>. Only valid for the ArgumentsRealm realm class\n\
 \   --argumentsRealm.roles.<user>  = Roles for user <user> (comma separated). Only valid for the ArgumentsRealm realm class\n\n\
 \   --fileRealm.configFile         = File containing users/passwds/roles. Only valid for the FileRealm realm class\n\n\
-Access logging:\n\
+\ Access logging:\n\
 \   --accessLoggerClassName        = Set the access logger class to use for user authentication. Defaults to disabled\n\
 \   --simpleAccessLogger.format    = The log format to use. Supports combined/common/resin/custom (SimpleAccessLogger only)\n\
 \   --simpleAccessLogger.file      = The location pattern for the log file(SimpleAccessLogger only)\n\n
@@ -143,6 +155,7 @@ HttpsListener.ErrorGettingContext=Error getting the SSL context object
 HttpsListener.KeyCount=Keys/certificates found: [#0]
 HttpsListener.KeyFound=Key: [#0] - [#1]
 HttpsListener.KeyStoreNotFound=No SSL key store found at [#0]
+HttpsListener.ExcludeCiphers=Exclude Ciphers [#0]
 
 Ajp13ConnectorFactory.NotSupported=\
   AJP support is removed in Winstone 3.0 due to Jetty 9 not supporting AJP. \


### PR DESCRIPTION
since jetty 9.4.12.v20180830 default cipher exclusion has been changed with https://github.com/eclipse/jetty.project/issues/2807. We need  a configuration parameter so the user can choose their prefer exclusion list.