### PR TITLE
Stream does not need to be closed given try-with-resources is in place.

### DIFF
--- a/src/main/java/winstone/tools/WinstoneControl.java
+++ b/src/main/java/winstone/tools/WinstoneControl.java
@@ -81,7 +81,6 @@ public class WinstoneControl {
             socket.setSoTimeout(TIMEOUT);
             try(OutputStream out = socket.getOutputStream()){
                 out.write( Launcher.SHUTDOWN_TYPE );
-                out.close();
                 Logger.log( Logger.INFO, TOOLS_RESOURCES, "WinstoneControl.ShutdownOK", host, port );
             }
         }


### PR DESCRIPTION
try-with-resources was introduced in [this commit](https://github.com/jenkinsci/winstone/commit/aed91a80cd509da955f749c4539bc3599ef87ee6#commitcomment-33011448) and therefore the stream must not be closed manually.

@olamy 