### PR TITLE
Using SupportLogFormatter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci</groupId>
     <artifactId>jenkins</artifactId>
-    <version>1.50</version>
+    <version>1.51</version>
     <relativePath />
   </parent>
 
@@ -256,6 +256,12 @@
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-jmx</artifactId>
       <version>${jetty.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.jenkins.lib</groupId>
+      <artifactId>support-log-formatter</artifactId>
+      <version>1.0</version>
     </dependency>
 
     <!--  See https://github.com/eclipse/jetty.project/issues/134

--- a/src/main/java/winstone/Launcher.java
+++ b/src/main/java/winstone/Launcher.java
@@ -6,6 +6,7 @@
  */
 package winstone;
 
+import io.jenkins.lib.support_log_formatter.SupportLogFormatter;
 import org.eclipse.jetty.jmx.MBeanContainer;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.util.log.JavaUtilLog;
@@ -29,6 +30,8 @@ import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.ConsoleHandler;
+import java.util.logging.Handler;
 import java.util.logging.Level;
 
 /**
@@ -329,6 +332,11 @@ public class Launcher implements Runnable {
      * listener thread. For now, just shut it down with a control-C.
      */
     public static void main(String argv[]) throws IOException {
+        for (Handler h : java.util.logging.Logger.getLogger("").getHandlers()) {
+            if (h instanceof ConsoleHandler) {
+                ((ConsoleHandler) h).setFormatter(new SupportLogFormatter());
+            }
+        }
         Log.setLog(new JavaUtilLog());  // force java.util.logging for consistency & backward compatibility
 
         Map args = getArgsFromCommandLine(argv);


### PR DESCRIPTION
API from https://github.com/jenkinsci/support-core-plugin/pull/168, now to produce one-line logs from `jenkins.war`. [Discussion](https://groups.google.com/d/msg/jenkinsci-dev/4PTMMwQNfjw/qVZBT379BgAJ)

```
…
2019-04-10 23:23:36.149+0000 [id=46]	INFO	hudson.model.UpdateSite#updateData: Obtained the latest update center data file for UpdateSource default
2019-04-10 23:23:36.507+0000 [id=32]	INFO	hudson.model.UpdateSite#updateData: Obtained the latest update center data file for UpdateSource default
2019-04-10 23:23:36.773+0000 [id=46]	INFO	h.m.DownloadService$Downloadable#load: Obtained the updated data file for hudson.tasks.Maven.MavenInstaller
…
```

@jenkinsci/code-reviewers esp. @batmat