### PR TITLE
Jetty upgrade 9.4.16.v20190411

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 ===
 
+## 5.3
+
+Release date: April ?, 2019
+
+* Update Jetty from `9.4.15.v20190215` to `9.4.16.v20190411`
+  * [9.4.16 changelog](https://github.com/eclipse/jetty.project/releases/tag/jetty-9.4.16.v20190411)
+
 ## 5.2
 
 Release date: March 22, 2019

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
   <url>https://github.com/jenkinsci/winstone</url>
 
   <properties>
-    <jetty.version>9.4.15.v20190215</jetty.version>
+    <jetty.version>9.4.16.v20190411</jetty.version>
     <alpn.api.version>1.1.3.v20160715</alpn.api.version>
     <java.level>8</java.level>
     <!-- TODO: remove once FindBugs issues are fixed. 57 so far -->


### PR DESCRIPTION
Signed-off-by: olivier lamy <olamy@apache.org>