### PR TITLE
Update jetty to 9.4.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 ===
 
+## 5.4
+
+Release date: June ?, 2019
+
+* Update Jetty from `9.4.18.v20190429` to `9.4.19.v20190610`
+  * [9.4.19 changelog](https://github.com/eclipse/jetty.project/releases/tag/jetty-9.4.19.v20190610)
+
 ## 5.3
 
 Release date: May 8, 2019
@@ -31,12 +38,12 @@ Release date: Aug 29, 2018
 
 * [JENKINS-52358](https://issues.jenkins-ci.org/browse/JENKINS-52358) - Fix broken Http/2 support (regression in 4.4)
 * [JENKINS-52121](https://issues.jenkins-ci.org/browse/JENKINS-52121) - `sessionEviction` flag was missing in the embedded Winstone Documentation
-* [JENKINS-53239](https://issues.jenkins-ci.org/browse/JENKINS-53239) - Use default Jetty `QueuedThreadPool` instead of the custom `winstone.BoundedExecutorService`. 
+* [JENKINS-53239](https://issues.jenkins-ci.org/browse/JENKINS-53239) - Use default Jetty `QueuedThreadPool` instead of the custom `winstone.BoundedExecutorService`.
 Related issues:
   * [JENKINS-33412](https://issues.jenkins-ci.org/browse/JENKINS-33412) - Jenkins locks when started in HTTPS mode on a host with 37+ processors.
-  * [JENKINS-52804](https://issues.jenkins-ci.org/browse/JENKINS-52804) - 
+  * [JENKINS-52804](https://issues.jenkins-ci.org/browse/JENKINS-52804) -
   Jenkins web GUI hangs when using a computer with more then 70 CPU's.
-  * [JENKINS-51136](https://issues.jenkins-ci.org/browse/JENKINS-51136) - 
+  * [JENKINS-51136](https://issues.jenkins-ci.org/browse/JENKINS-51136) -
   Jenkins UI hangs 2.117 - 2.119.
 
 Breaking changes:
@@ -58,34 +65,34 @@ Update Jetty from `9.4.8.v20171121` to `9.4.11.v20180605`
 
 Release date: May 05, 2018
 
-* [PR-47](https://github.com/jenkinsci/winstone/pull/47) - 
-Option to enable [Jetty JMX](https://www.eclipse.org/jetty/documentation/9.4.x/jmx-chapter.html) 
+* [PR-47](https://github.com/jenkinsci/winstone/pull/47) -
+Option to enable [Jetty JMX](https://www.eclipse.org/jetty/documentation/9.4.x/jmx-chapter.html)
 
 ## 4.2
 
 Release date: April 1, 2018
 
 * [PR #44](https://github.com/jenkinsci/winstone/pull/44) -
-Update Jetty from `9.4.5.v20170502` to `9.4.8.v20171121` 
+Update Jetty from `9.4.5.v20170502` to `9.4.8.v20171121`
   * [9.4.8 changelog](https://github.com/eclipse/jetty.project/releases/tag/jetty-9.4.8.v20171121)
   * [9.4.7 changelog](https://github.com/eclipse/jetty.project/releases/tag/jetty-9.4.7.v20170914)
   * [9.4.6 changelog](https://github.com/eclipse/jetty.project/releases/tag/jetty-9.4.6.v20170531)
 * [PR #46](https://github.com/jenkinsci/winstone/pull/46) -
-Internal: Update codebase to use the standard [Jenkins parent POM](https://github.com/jenkinsci/pom) 
+Internal: Update codebase to use the standard [Jenkins parent POM](https://github.com/jenkinsci/pom)
 
 ## 4.1.2
 
 Release date: Feb 23, 2017
 
 * [JENKINS-49596](https://issues.jenkins-ci.org/browse/JENKINS-49596) -
-Increase the default idle session eviction timeout to 30 minutes. 
+Increase the default idle session eviction timeout to 30 minutes.
 
 ## 4.1.1
 
 Release date: Feb 22, 2017
 
 * [JENKINS-49596](https://issues.jenkins-ci.org/browse/JENKINS-49596) -
-Prevent User session memory leak by setting the default idle session eviction timeout to 3 minutes. 
+Prevent User session memory leak by setting the default idle session eviction timeout to 3 minutes.
 * Allow configuring the session eviction timeout via the `-sessionEviction` command-line option.
 
 ##4.1
@@ -100,7 +107,7 @@ Release date: May 04, 2017
 
 * Update Jetty from `9.2.15.v20160210` to `9.4.5.v20170502`
 * Remove the deprecated [SPDY](http://www.eclipse.org/jetty/documentation/9.1.5.v20140505/spdy.html) protocol mode.
-* [JENKINS-40693](https://issues.jenkins-ci.org/browse/JENKINS-40693) - 
+* [JENKINS-40693](https://issues.jenkins-ci.org/browse/JENKINS-40693) -
 Jetty 9.4.5: Prevent the <i>400 Bad Host header</i> error for <code>HttpChannelOverHttp</code> when operating behind reverse proxy
 ([Jetty issue #592](https://github.com/eclipse/jetty.project/issues/592)).
 * Update minimal Java requirement to Java 8

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
   <url>https://github.com/jenkinsci/winstone</url>
 
   <properties>
-    <jetty.version>9.4.18.v20190429</jetty.version>
+    <jetty.version>9.4.19.v20190610</jetty.version>
     <alpn.api.version>1.1.3.v20160715</alpn.api.version>
     <java.level>8</java.level>
     <!-- TODO: remove once FindBugs issues are fixed. 57 so far -->


### PR DESCRIPTION
- Changelog [here](https://github.com/eclipse/jetty.project/releases/tag/jetty-9.4.19.v20190610)