### PR TITLE
Configuration for Release Drafter and Dependabot

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,9 @@
+version: 1
+update_configs:
+- package_manager: "java:maven"
+  directory: "/"
+  update_schedule: "weekly"
+  default_reviewers:
+    - "jglick"
+    - "oleg-nenashev"
+    - "olamy"

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,2 @@
+_extends: .github
+tag-template: winstone-$NEXT_MINOR_VERSION


### PR DESCRIPTION
To avoid the need for manual stuff like #68. On hold pending [INFRA-2317](https://issues.jenkins-ci.org/browse/INFRA-2317) so I can enable these apps.