### PR TITLE
Remove version number

### DIFF
--- a/src/main/resources/winstone/LocalStrings.properties
+++ b/src/main/resources/winstone/LocalStrings.properties
@@ -1,4 +1,4 @@
-ServerVersion=Winstone Servlet Engine v4.0
+ServerVersion=Winstone Servlet Engine
 
 Logger.StreamWriteError=Error writing log message: [#0]
 


### PR DESCRIPTION
This version number has been wrong for more than two years (since https://github.com/jenkinsci/winstone/releases/tag/winstone-4.1)

Better to just give up.

It's apparently only used in two messages (a log message and usage instructions) anyway.

Semi-related to [JENKINS-33814](https://issues.jenkins-ci.org/browse/JENKINS-33814), which was about the same problem in early 2016.