### PR TITLE
[JENKINS-60821] set the name of Jetty's thread pool

### DIFF
--- a/src/main/java/winstone/Launcher.java
+++ b/src/main/java/winstone/Launcher.java
@@ -158,6 +158,7 @@ public class Launcher implements Runnable {
 
             int qtpMaxThread = Option.QTP_MAXTHREADS.get(args);
             QueuedThreadPool queuedThreadPool = qtpMaxThread>0?new QueuedThreadPool(qtpMaxThread):new QueuedThreadPool();
+            queuedThreadPool.setName("Jetty Thread Pool");
             this.server = new Server(queuedThreadPool);
 
 

--- a/src/main/java/winstone/Launcher.java
+++ b/src/main/java/winstone/Launcher.java
@@ -158,7 +158,7 @@ public class Launcher implements Runnable {
 
             int qtpMaxThread = Option.QTP_MAXTHREADS.get(args);
             QueuedThreadPool queuedThreadPool = qtpMaxThread>0?new QueuedThreadPool(qtpMaxThread):new QueuedThreadPool();
-            queuedThreadPool.setName("Jetty Thread Pool");
+            queuedThreadPool.setName("Jetty (winstone)");
             this.server = new Server(queuedThreadPool);
 
 


### PR DESCRIPTION
[JENKINS-60821](https://issues.jenkins-ci.org/browse/JENKINS-60821) 
by default any thread created from a QueudThreadPool has `qtp` as the
base of its name.  Given there could be other usage of QueuedThreadPool
and that it is usefull to be friendly set the name of the threadpool so
something helpful and hopefully unique.