### PR TITLE
[JENKINS-60409] --requestFormContentSize no longer works

### DIFF
--- a/src/main/java/winstone/HostConfiguration.java
+++ b/src/main/java/winstone/HostConfiguration.java
@@ -168,6 +168,11 @@ public class HostConfiguration {
                 } finally {
                     t.setContextClassLoader(ccl);
                 }
+                int maxParameterCount = Option.MAX_PARAM_COUNT.get(args);
+                if (maxParameterCount > 0) {
+                    setMaxFormKeys(maxParameterCount);
+                }
+                setMaxFormContentSize(Option.REQUEST_FORM_CONTENT_SIZE.get(args));
             }
 
             @Override

--- a/src/main/java/winstone/Launcher.java
+++ b/src/main/java/winstone/Launcher.java
@@ -162,13 +162,6 @@ public class Launcher implements Runnable {
             this.server = new Server(queuedThreadPool);
 
 
-            int maxParameterCount = Option.MAX_PARAM_COUNT.get(args);
-            if (maxParameterCount>0) {
-                server.setAttribute("org.eclipse.jetty.server.Request.maxFormKeys",maxParameterCount);
-            }
-            server.setAttribute("org.eclipse.jetty.server.Request.maxFormContentSize",
-                    Option.REQUEST_FORM_CONTENT_SIZE.get(args));
-
             // Open the web apps
             this.hostGroup = new HostGroup(server, commonLibCL,
                     commonLibCLPaths.toArray(new File[0]), args);

--- a/src/test/java/winstone/FormSubmissionTest.java
+++ b/src/test/java/winstone/FormSubmissionTest.java
@@ -9,13 +9,11 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.commons.io.IOUtils;
 import static org.junit.Assert.assertTrue;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 
 public class FormSubmissionTest extends AbstractWinstoneTest {
 
-    @Ignore("TODO indeed fails after 200_000 regardless of requestFormContentSize option")
     @Issue("JENKINS-60409")
     @Test
     public void largeForm() throws Exception {
@@ -24,6 +22,9 @@ public class FormSubmissionTest extends AbstractWinstoneTest {
         args.put("prefix", "/");
         args.put("httpPort", "59009");
         args.put("httpListenAddress", "127.0.0.2");
+        /* To see it fail:
+        args.put("requestFormContentSize", "999");
+        */
         winstone = new Launcher(args);
 
         for (int size = 1; size <= 9_999_999; size *= 3) {

--- a/src/test/java/winstone/FormSubmissionTest.java
+++ b/src/test/java/winstone/FormSubmissionTest.java
@@ -1,0 +1,45 @@
+package winstone;
+
+import com.meterware.httpunit.PostMethodWebRequest;
+import com.meterware.httpunit.WebRequest;
+import com.meterware.httpunit.WebResponse;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.commons.io.IOUtils;
+import static org.junit.Assert.assertTrue;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+
+public class FormSubmissionTest extends AbstractWinstoneTest {
+
+    @Ignore("TODO indeed fails after 200_000 regardless of requestFormContentSize option")
+    @Issue("JENKINS-60409")
+    @Test
+    public void largeForm() throws Exception {
+        Map<String,String> args = new HashMap<String,String>();
+        args.put("warfile", "target/test-classes/test.war");
+        args.put("prefix", "/");
+        args.put("httpPort", "59009");
+        args.put("httpListenAddress", "127.0.0.2");
+        winstone = new Launcher(args);
+
+        for (int size = 1; size <= 9_999_999; size *= 3) {
+            System.out.println("trying size " + size);
+            WebRequest wreq = new PostMethodWebRequest("http://127.0.0.2:59009/AcceptFormServlet");
+            StringBuilder b = new StringBuilder();
+            for (int i = 0; i < size; i++) {
+                b.append('.');
+            }
+            wreq.setParameter("x", b.toString());
+            WebResponse wresp = wc.getResponse(wreq);
+            try (InputStream content = wresp.getInputStream()) {
+                assertTrue("Loading AcceptFormServlet at size " + size, content.available() > 0);
+                assertEquals("correct response at size " + size, "received " + (size + "x=".length()) + " bytes", IOUtils.toString(content, StandardCharsets.US_ASCII));
+            }
+        }
+    }
+
+}

--- a/src/test/java/winstone/testApplication/servlets/AcceptFormServlet.java
+++ b/src/test/java/winstone/testApplication/servlets/AcceptFormServlet.java
@@ -1,0 +1,26 @@
+package winstone.testApplication.servlets;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+public class AcceptFormServlet extends HttpServlet {
+
+    @Override
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        resp.setContentType("text/plain");
+        try (PrintWriter pw = resp.getWriter()) {
+            try {
+                req.getParameterNames();
+            } catch (Exception x) {
+                x.printStackTrace(pw);
+                return;
+            }
+            pw.print("received " + req.getContentLength() + " bytes");
+        }
+    }
+
+}

--- a/src/testwebapp/WEB-INF/web.xml
+++ b/src/testwebapp/WEB-INF/web.xml
@@ -44,7 +44,12 @@
 		</init-param>
 		<load-on-startup>1</load-on-startup>
 	</servlet>
-	
+
+	<servlet>
+		<servlet-name>AcceptFormServlet</servlet-name>
+		<servlet-class>winstone.testApplication.servlets.AcceptFormServlet</servlet-class>
+	</servlet>
+
 	<servlet>
 		<servlet-name>UnavailableAtInitServlet</servlet-name>
 		<servlet-class>winstone.testApplication.servlets.UnavailableServlet</servlet-class>
@@ -81,6 +86,11 @@
 		<url-pattern>/CountRequestsServlet</url-pattern>
 	</servlet-mapping>
 	
+	<servlet-mapping>
+		<servlet-name>AcceptFormServlet</servlet-name>
+		<url-pattern>/AcceptFormServlet</url-pattern>
+	</servlet-mapping>
+
 	<!-- test that an explicit mapping overrides the default JSP one -->
 	<servlet-mapping>
 		<servlet-name>loadOnStartupJSP</servlet-name>


### PR DESCRIPTION
[JENKINS-60409](https://issues.jenkins-ci.org/browse/JENKINS-60409)

Amending #20 because this feature stopped working after #68 in 5.4 with https://github.com/eclipse/jetty.project/pull/3899.

- [X] Reproduce problem in unit test
- [x] Fix
- [X] Verified in context:
* run a Jenkins `master` build
* install `kubernetes` plugin
* add a K8s cloud
* start adding pod templates and clicking **Apply** until the error is seen (once the `Content-Length` goes above 200_000)
* apply
```diff
diff --git war/pom.xml war/pom.xml
index 3f816fb897..c5d0355ab1 100644
--- war/pom.xml
+++ war/pom.xml
@@ -100,7 +100,7 @@ THE SOFTWARE.
       -->
       <groupId>org.jenkins-ci</groupId>
       <artifactId>winstone</artifactId>
-      <version>5.8</version>
+      <version>5.9-rc529.8a8a146c88e5</version>
       <scope>test</scope>
     </dependency>
     <dependency>
```
* run with this patched WAR
* add some more pod templates and **Apply** to see that there is no error even past 200_000