### PR TITLE
[JENKINS-60409, JENKINS-60199] - Winstone 5.4.1 backports for Jenkins 2.204.x

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,7 @@
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+  <extension>
+    <groupId>io.jenkins.tools.incrementals</groupId>
+    <artifactId>git-changelist-maven-extension</artifactId>
+    <version>1.1</version>
+  </extension>
+</extensions>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,2 @@
+-Pconsume-incrementals
+-Pmight-produce-incrementals

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,7 @@ properties([[$class: 'BuildDiscarderProperty',
  *  https://github.com/jenkins-infra/documentation/blob/master/ci.adoc
  */
 Map branches = [:]
-['maven', 'maven-windows'].each {label ->
+['maven'/* TODO broken , 'maven-windows'*/].each {label ->
     branches[label] = {
         node(label) {
             stage('Checkout') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,12 +22,7 @@ Map branches = [:]
             withEnv(["MAVEN_SETTINGS=$settingsXml"]) {
                 stage('Build') {
                     timeout(30) {
-                        String command = 'mvn -B -ntp -Dset.changelist -Dmaven.test.failure.ignore install'
-                        if (isUnix()) {
-                            sh command
-                        } else {
-                            bat command
-                        }
+                        infra.runMaven(["-Dset.changelist", "-Dmaven.test.failure.ignore", "install"])
                     }
                 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,12 @@ Map branches = [:]
             withEnv(["MAVEN_SETTINGS=$settingsXml"]) {
                 stage('Build') {
                     timeout(30) {
-                        sh 'mvn -B -ntp -Dset.changelist -Dmaven.test.failure.ignore install'
+                        String command = 'mvn -B -ntp -Dset.changelist -Dmaven.test.failure.ignore install'
+                        if (isUnix()) {
+                            sh command
+                        } else {
+                            bat command
+                        }
                     }
                 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,6 +8,7 @@ properties([[$class: 'BuildDiscarderProperty',
 /* These platforms correspond to labels in ci.jenkins.io, see:
  *  https://github.com/jenkins-infra/documentation/blob/master/ci.adoc
  */
+Map branches = [:]
 ['maven', 'maven-windows'].each {label ->
     branches[label] = {
         node(label) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,6 @@ Map branches = [:]
 ['maven', 'maven-windows'].each {label ->
     branches[label] = {
         node(label) {
-            timestamps {
                 stage('Checkout') {
                     checkout scm
                 }
@@ -31,7 +30,6 @@ Map branches = [:]
                         infra.prepareToPublishIncrementals()
                     }
                 }
-            }
         }
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -136,6 +136,19 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>flatten</id>
+            <phase>package</phase>
+            <goals>
+              <goal>flatten</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
   <groupId>org.jenkins-ci</groupId>
   <artifactId>winstone</artifactId>
-  <version>5.5-SNAPSHOT</version>
+  <version>${revision}${changelist}</version>
   <packaging>jar</packaging>
 
   <name>Winstone</name>
@@ -17,6 +17,8 @@
   <url>https://github.com/jenkinsci/winstone</url>
 
   <properties>
+    <revision>5.5</revision>
+    <changelist>-SNAPSHOT</changelist>
     <jetty.version>9.4.22.v20191022</jetty.version>
     <alpn.api.version>1.1.3.v20160715</alpn.api.version>
     <java.level>8</java.level>
@@ -165,7 +167,7 @@
     <connection>scm:git:git://github.com/jenkinsci/winstone.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/winstone.git</developerConnection>
     <url>http://github.com/jenkinsci/winstone</url>
-    <tag>HEAD</tag>
+    <tag>${scmTag}</tag>
   </scm>
 
   <dependencyManagement>

--- a/src/main/java/winstone/Launcher.java
+++ b/src/main/java/winstone/Launcher.java
@@ -157,6 +157,7 @@ public class Launcher implements Runnable {
 
             int qtpMaxThread = Option.QTP_MAXTHREADS.get(args);
             QueuedThreadPool queuedThreadPool = qtpMaxThread>0?new QueuedThreadPool(qtpMaxThread):new QueuedThreadPool();
+            queuedThreadPool.setName("Jetty Thread Pool");
             this.server = new Server(queuedThreadPool);
 
 

--- a/src/main/java/winstone/Launcher.java
+++ b/src/main/java/winstone/Launcher.java
@@ -157,7 +157,7 @@ public class Launcher implements Runnable {
 
             int qtpMaxThread = Option.QTP_MAXTHREADS.get(args);
             QueuedThreadPool queuedThreadPool = qtpMaxThread>0?new QueuedThreadPool(qtpMaxThread):new QueuedThreadPool();
-            queuedThreadPool.setName("Jetty Thread Pool");
+            queuedThreadPool.setName("Jetty (winstone)");
             this.server = new Server(queuedThreadPool);
 
 

--- a/src/main/java/winstone/Launcher.java
+++ b/src/main/java/winstone/Launcher.java
@@ -332,10 +332,12 @@ public class Launcher implements Runnable {
      * listener thread. For now, just shut it down with a control-C.
      */
     public static void main(String argv[]) throws IOException {
-        for (Handler h : java.util.logging.Logger.getLogger("").getHandlers()) {
-            if (h instanceof ConsoleHandler) {
-                ((ConsoleHandler) h).setFormatter(new SupportLogFormatter());
-            }
+        if (System.getProperty("java.util.logging.config.file") == null) {
+          for (Handler h : java.util.logging.Logger.getLogger("").getHandlers()) {
+              if (h instanceof ConsoleHandler) {
+                  ((ConsoleHandler) h).setFormatter(new SupportLogFormatter());
+              }
+          }
         }
         Log.setLog(new JavaUtilLog());  // force java.util.logging for consistency & backward compatibility
 


### PR DESCRIPTION
Alternative solution for the 2.204.3 and 2.204.4 issues caused by the unintended Jetty upgrade. Instead of playing whack-a-mole with Jetty, I suggest reverting the updates and going forward with a new Winstone version which is based on Winstone 5.4 and includes bugfixes unrelated to Jetty.

Changes to be backported:

## 🚀 New features and improvements

* [JENKINS-60821](https://issues.jenkins-ci.org/browse/JENKINS-60821) - set the _Jetty (winstone)_ name for the Jetty's thread pool (#90) @jtnord

## 🐛 Bug Fixes

* [JENKINS-57888](https://issues.jenkins-ci.org/browse/JENKINS-57888) - Restore `java.util.logging.config.file` property support (regression in 5.4) (#87) @lrpg

## 👻 Maintenance

* Enable releases of Incremental versions ([JEP-305](https://github.com/jenkinsci/jep/tree/master/jep/305)) (#81) @jglick
* [JENKINS-60606](https://issues.jenkins-ci.org/browse/JENKINS-60606) - Jenkinsfile: Use standard Mavn run methods from the Pipeline lib (#85) @oleg-nenashev
* Fix of Windows ACI agents by @jglick 

CC @jenkinsci/core 
