### PR TITLE
[JENKINS-66379] use default keystore format

### DIFF
--- a/src/main/java/winstone/AbstractSecuredConnectorFactory.java
+++ b/src/main/java/winstone/AbstractSecuredConnectorFactory.java
@@ -61,14 +61,14 @@ public abstract class AbstractSecuredConnectorFactory implements ConnectorFactor
                 throw new WinstoneException(MessageFormat.format("--{0} and --{1} are mutually exclusive", Option.HTTPS_KEY_STORE, Option.HTTPS_PRIVATE_KEY));
 
             if (keyStore!=null) {
-                // load from Java style JKS
+                // load from default Keystore
                 if (!keyStore.exists() || !keyStore.isFile())
                     throw new WinstoneException(SSL_RESOURCES.getString(
                         "HttpsListener.KeyStoreNotFound", keyStore.getPath()));
 
                 this.keystorePassword = pwd;
 
-                keystore = KeyStore.getInstance("JKS");
+                keystore = KeyStore.getInstance(KeyStore.getDefaultType());
                 try(InputStream inputStream = new FileInputStream(keyStore)){
                     keystore.load( inputStream, this.keystorePassword.toCharArray());
                 }
@@ -81,7 +81,7 @@ public abstract class AbstractSecuredConnectorFactory implements ConnectorFactor
                     PrivateKey key = readPEMRSAPrivateKey(fileReader);
 
                     this.keystorePassword = "changeit";
-                    keystore = KeyStore.getInstance( "JKS" );
+                    keystore = KeyStore.getInstance(KeyStore.getDefaultType());
                     keystore.load( null );
                     keystore.setKeyEntry( "hudson", key, keystorePassword.toCharArray(), new Certificate[]{ cert } );
                 }


### PR DESCRIPTION
[JENKINS-66379](https://issues.jenkins.io/browse/JENKINS-66379)
The JKS keystore is insecure and is some environments not even allowed.

We do not care what format the keystore is in, so just use the default.

If someone has a non default keystore yet is using a keystore here then
this will break on upgrade, however it is unlikely that they would be
having a non default keystore as the normal reason for doing that is due
to a restriction like FIPS-140 and given the keystore we require has a
key using JDK here would be non compliant.

no unit tests as this requires changing java security properties for the JVM.  Existing tests will ensure there are no regressions for the normal cases.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
