### PR TITLE
Add an option to write the listening port to a file

### DIFF
--- a/src/test/java/winstone/HttpConnectorFactoryTest.java
+++ b/src/test/java/winstone/HttpConnectorFactoryTest.java
@@ -1,17 +1,26 @@
 package winstone;
 
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
 import org.eclipse.jetty.server.LowResourceMonitor;
 import org.eclipse.jetty.server.ServerConnector;
+import org.junit.Rule;
 import org.junit.Test;
-import winstone.Launcher;
+import org.junit.rules.TemporaryFolder;
 
 import java.util.HashMap;
 import java.util.Map;
+
+import static winstone.Launcher.WINSTONE_PORT_FILE_NAME_PROPERTY;
 
 /**
  * @author Kohsuke Kawaguchi
  */
 public class HttpConnectorFactoryTest extends AbstractWinstoneTest {
+
+    @Rule
+    public TemporaryFolder tmp = new TemporaryFolder();
 
     @Test
     public void testListenAddress() throws Exception {
@@ -30,5 +39,25 @@ public class HttpConnectorFactoryTest extends AbstractWinstoneTest {
         assertNotNull(lowResourceMonitor);
         assertFalse(lowResourceMonitor.isLowOnResources());
         assertTrue(lowResourceMonitor.isAcceptingInLowResources());
+    }
+
+    @Test
+    public void writePortInFile() throws Exception {
+        Map<String,String> args = new HashMap<>();
+        args.put("warfile", "target/test-classes/test.war");
+        args.put("prefix", "/");
+        args.put("httpPort", "0");
+        File portFile = tmp.newFile("jenkins.port");
+        System.setProperty(WINSTONE_PORT_FILE_NAME_PROPERTY, portFile.getAbsolutePath());
+        try {
+            winstone = new Launcher(args);
+            int port = ((ServerConnector) winstone.server.getConnectors()[0]).getLocalPort();
+            try (BufferedReader reader = new BufferedReader(new FileReader(portFile))) {
+                String portInFile = reader.readLine();
+                assertEquals(Integer.toString(port), portInFile);
+            }
+        } finally {
+            System.clearProperty(WINSTONE_PORT_FILE_NAME_PROPERTY);
+        }
     }
 }


### PR DESCRIPTION
The context for this pull request are test flakes observed both in RealJenkinsRule and running ATH with multiple controllers launched.

In both cases, a random port was generated then passed to winstone. The problem is that by the time Jetty tries to bind this port, it could become used by another instance.

This is taking another aproach:
* pass `--httpPort=0` to winstone, let Jetty allocate a random port
* pass the system property `winstone.portFileName`. In that case, winstone will write the used port in that file.

This file can then be used by `RealJenkinsRule` or the ATH to obtain the actual port to use to access the instance.

To test this change
* build winstone
* build jenkins with patched winstone
* build jenkins-test-harness with patched Jenkins

Flagging as draft until I have downstream PRs set up.

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
