### PR TITLE
Bump `support-log-formatter` from 1.0 to 1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -291,7 +291,7 @@
     <dependency>
       <groupId>io.jenkins.lib</groupId>
       <artifactId>support-log-formatter</artifactId>
-      <version>1.0</version>
+      <version>1.1</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci</groupId>


### PR DESCRIPTION
See [the release notes](https://github.com/jenkinsci/lib-support-log-formatter/releases/tag/support-log-formatter-1.1).