### PR TITLE
Replace deprecated `org.eclipse.jetty.util.B64Code` with non-deprecated `java.util.Base64`

### DIFF
--- a/src/main/java/winstone/AbstractSecuredConnectorFactory.java
+++ b/src/main/java/winstone/AbstractSecuredConnectorFactory.java
@@ -8,7 +8,6 @@
 package winstone;
 
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.util.B64Code;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import winstone.cmdline.Option;
 
@@ -33,6 +32,7 @@ import java.security.cert.X509Certificate;
 import java.security.spec.RSAPrivateKeySpec;
 import java.text.MessageFormat;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Enumeration;
 import java.util.Map;
 import java.util.logging.Level;
@@ -134,7 +134,7 @@ public abstract class AbstractSecuredConnectorFactory implements ConnectorFactor
                         continue;
                     }
                     if ( in ) {
-                        baos.write( B64Code.decode( line ) );
+                        baos.write(Base64.getDecoder().decode(line.trim()));
                     }
                 }
             } finally {


### PR DESCRIPTION
Per [the Javadoc](https://www.eclipse.org/jetty/javadoc/jetty-9/org/eclipse/jetty/util/B64Code.html):

> Unlike `decode(char[])`, extra whitespace is ignored.

Therefore I added a `trim()` to the string to strip extra whitespace before passing the result to `Base64.getDecoder().decode()`.

CC @olamy 