### PR TITLE
[JENKINS-68694] Bump Jetty from 9.4.48.v20220622 to 10.0.11

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,9 @@ updates:
       interval: "weekly"
     target-branch: "master"
     ignore:
-      # Restrict updates to jetty in the 9.4.x space
+      # Restrict updates to jetty in the 10.x space
       - dependency-name: "org.eclipse.jetty:*"
-        versions: [ ">=10" ]
+        versions: [ ">=11" ]
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ To run different web applications for diffent virtual hosts:
          / --httpsCertificate     file and the corresponding certificate file
        --httpsRedirectHttp      = redirect http requests to https (requires both --httpPort and --httpsPort)
        --http2Port              = set the http2 listening port. -1 to disable, Default is disabled
+       --httpsSniHostCheck      = if the SNI Host name must match when there is an SNI certificate. Check disabled per default
+       --httpsSniRequired       = if a SNI certificate is required. Disabled per default
        --http2ListenAddress     = set the http2 listening address. Default is all interfaces
        --excludeCipherSuites    = set the ciphers to exclude (comma separated, use blank quote " " to exclude none) (default is 
                                // Exclude weak / insecure ciphers 

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
   <properties>
     <revision>5.27</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jetty.version>9.4.48.v20220622</jetty.version>
+    <jetty.version>10.0.11</jetty.version>
     <alpn.api.version>1.1.3.v20160715</alpn.api.version>
     <!-- TODO: remove once SpotBugs issues are fixed. 29 so far -->
     <spotbugs.threshold>High</spotbugs.threshold>
@@ -72,6 +72,10 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
+          <!-- Uncomment to enable extra logging for debugging -->
+          <!-- <systemPropertyVariables> -->
+          <!--   <java.util.logging.config.file>src/test/resources/jul.properties</java.util.logging.config.file> -->
+          <!-- </systemPropertyVariables> -->
           <trimStackTrace>false</trimStackTrace> <!-- SUREFIRE-1226 workaround -->
         </configuration>
       </plugin>
@@ -284,8 +288,13 @@
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.websocket</groupId>
-      <artifactId>websocket-server</artifactId> <!-- or javax-websocket-server-impl -->
+      <artifactId>websocket-jetty-server</artifactId> <!-- or websocket-javax-server -->
       <version>${jetty.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-jdk14</artifactId>
+      <version>1.7.36</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/winstone/AbstractSecuredConnectorFactory.java
+++ b/src/main/java/winstone/AbstractSecuredConnectorFactory.java
@@ -137,7 +137,7 @@ public abstract class AbstractSecuredConnectorFactory implements ConnectorFactor
      * Used to get the base ssl context in which to create the server socket.
      * This is basically just so we can have a custom location for key stores.
      */
-    protected SslContextFactory getSSLContext( Map<String, String> args) {
+    protected SslContextFactory.Server getSSLContext( Map<String, String> args) {
         try {
             String privateKeyPassword;
 

--- a/src/main/java/winstone/Http2ConnectorFactory.java
+++ b/src/main/java/winstone/Http2ConnectorFactory.java
@@ -22,6 +22,8 @@ package winstone;
 
 import org.eclipse.jetty.alpn.ALPN;
 import org.eclipse.jetty.alpn.server.ALPNServerConnectionFactory;
+import org.eclipse.jetty.http.HttpCompliance;
+import org.eclipse.jetty.http.UriCompliance;
 import org.eclipse.jetty.http2.HTTP2Cipher;
 import org.eclipse.jetty.http2.server.HTTP2ServerConnectionFactory;
 import org.eclipse.jetty.server.Connector;
@@ -57,14 +59,18 @@ public class Http2ConnectorFactory extends AbstractSecuredConnectorFactory imple
 
         try {
             configureSsl( args, server );
-            SslContextFactory sslContextFactory = getSSLContext( args );
+            SslContextFactory.Server sslContextFactory = getSSLContext( args );
             sslContextFactory.setCipherComparator(HTTP2Cipher.COMPARATOR);
 
             // HTTPS Configuration
             HttpConfiguration https_config = new HttpConfiguration();
             https_config.setSecureScheme("https");
             https_config.setSecurePort(listenPort);
-            https_config.addCustomizer(new SecureRequestCustomizer());
+            https_config.setHttpCompliance(HttpCompliance.RFC7230);
+            https_config.setUriCompliance(UriCompliance.LEGACY);
+            SecureRequestCustomizer secureRequestCustomizer = new SecureRequestCustomizer();
+            secureRequestCustomizer.setSniHostCheck(Option.HTTPS_SNI_HOST_CHECK.get(args));
+            https_config.addCustomizer(secureRequestCustomizer);
 
             // HTTP/2 Connection Factory
             HTTP2ServerConnectionFactory h2 = new HTTP2ServerConnectionFactory(https_config);

--- a/src/main/java/winstone/HttpsConnectorFactory.java
+++ b/src/main/java/winstone/HttpsConnectorFactory.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.handler.HandlerList;
 import org.eclipse.jetty.server.handler.SecuredRedirectHandler;
 
@@ -63,9 +64,11 @@ public class HttpsConnectorFactory extends AbstractSecuredConnectorFactory imple
             .withRequestHeaderSize(Option.REQUEST_HEADER_SIZE.get(args))
             .withResponseHeaderSize(Option.RESPONSE_HEADER_SIZE.get(args))
             .withKeepAliveTimeout(Option.HTTPS_KEEP_ALIVE_TIMEOUT.get(args))
+            .withSniHostCheck(Option.HTTPS_SNI_HOST_CHECK.get(args))
+            .withSniRequired(Option.HTTPS_SNI_REQUIRED.get(args))
             .withSslContext(getSSLContext(args));
-        Connector connector = scb.build();
-        server.addConnector(connector);
-        return connector;
+        ServerConnector sc = scb.build();
+        server.addConnector(sc);
+        return sc;
     }
 }

--- a/src/main/java/winstone/Launcher.java
+++ b/src/main/java/winstone/Launcher.java
@@ -16,8 +16,6 @@ import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.LowResourceMonitor;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
-import org.eclipse.jetty.util.log.JavaUtilLog;
-import org.eclipse.jetty.util.log.Log;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import winstone.cmdline.CmdLineParser;
 import winstone.cmdline.Option;
@@ -380,7 +378,6 @@ public class Launcher implements Runnable {
               }
           }
         }
-        Log.setLog(new JavaUtilLog());  // force java.util.logging for consistency & backward compatibility
 
         Map<String, String> args = getArgsFromCommandLine(argv);
 

--- a/src/main/java/winstone/cmdline/Option.java
+++ b/src/main/java/winstone/cmdline/Option.java
@@ -72,6 +72,8 @@ public class Option<T> {
     public static final OFile HTTPS_PRIVATE_KEY=file("httpsPrivateKey");
     public static final OString HTTPS_EXCLUDE_CIPHER_SUITES=string("excludeCipherSuites");
     public static final OBoolean HTTPS_REDIRECT_HTTP=bool("httpsRedirectHttp", false);
+    public static final OBoolean HTTPS_SNI_HOST_CHECK=bool("httpsSniHostCheck", false);
+    public static final OBoolean HTTPS_SNI_REQUIRED=bool("httpsSniRequired", false);
 
     public static final OInt AJP13_PORT=integer("ajp13"+_PORT,-1);
     public static final OString AJP13_LISTEN_ADDRESS=string("ajp13"+_LISTEN_ADDRESS);

--- a/src/main/resources/winstone/LocalStrings.properties
+++ b/src/main/resources/winstone/LocalStrings.properties
@@ -98,6 +98,8 @@ Launcher.UsageInstructions.Options=\
 \     / --httpsCertificate     file and the corresponding certificate file\n\
 \   --httpsRedirectHttp      = redirect http requests to https (requires both --httpPort and --httpsPort)\n\
 \   --http2Port              = set the http2 listening port. -1 to disable, Default is disabled\n\
+\   --httpsSniHostCheck     = if the SNI Host name must match when there is an SNI certificate. Check disabled per default\n\
+\   --httpsSniRequired       = if a SNI certificate is required. Disabled per default\n\
 \   --http2ListenAddress     = set the http2 listening address. Default is all interfaces\n\
 \   --excludeCipherSuites    = set the ciphers to exclude (comma separated, use blank quote " " to exclude none) (default is\n\
 \                           // Exclude weak / insecure ciphers \n\

--- a/src/test/resources/jul.properties
+++ b/src/test/resources/jul.properties
@@ -1,0 +1,5 @@
+handlers=java.util.logging.ConsoleHandler
+.level=INFO
+org.eclipse.jetty.level=ALL
+winstone.level=ALL
+java.util.logging.ConsoleHandler.level=FINEST


### PR DESCRIPTION
Do _not_ review. Merely filing this PR to have a record of a timestamped snapshot I just deployed. The timestamped snapshot is available here:

- https://repo.jenkins-ci.org/snapshots/org/jenkins-ci/winstone/5.22-SNAPSHOT/winstone-5.22-20211219.204048-2.jar
- https://repo.jenkins-ci.org/snapshots/org/jenkins-ci/winstone/5.22-SNAPSHOT/winstone-5.22-20211219.204048-2-sources.jar