### PR TITLE
Use UTF-8 source encoding

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
     <!-- TODO: remove once SpotBugs issues are fixed. 57 so far -->
     <spotbugs.failOnError>false</spotbugs.failOnError>
     <gitHubRepo>jenkinsci/winstone</gitHubRepo>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
   <licenses>


### PR DESCRIPTION
Fixes the following build warning:

```
[WARNING] Using platform encoding (UTF-8 actually) to copy filtered resources, i.e. build is platform dependent!
```