### PR TITLE
Remove `commonLibCLPaths`

### DIFF
--- a/src/main/java/winstone/HostConfiguration.java
+++ b/src/main/java/winstone/HostConfiguration.java
@@ -49,18 +49,16 @@ public class HostConfiguration {
     private Map<String, String> args;
     private Map<String,WebAppContext> webapps;
     private ClassLoader commonLibCL;
-    private File[] commonLibCLPaths;
     private MimeTypes mimeTypes = new MimeTypes();
     private final LoginService loginService;
 
     public HostConfiguration(Server server, String hostname, ClassLoader commonLibCL,
-                             File[] commonLibCLPaths, Map<String, String> args, File webappsDir) throws IOException {
+                             Map<String, String> args, File webappsDir) throws IOException {
         this.server = server;
         this.hostname = hostname;
         this.args = args;
         this.webapps = new Hashtable<>();
         this.commonLibCL = commonLibCL;
-        this.commonLibCLPaths = commonLibCLPaths;
 
         try {
             // Build the realm

--- a/src/main/java/winstone/HostGroup.java
+++ b/src/main/java/winstone/HostGroup.java
@@ -33,7 +33,7 @@ public class HostGroup {
 
     public HostGroup(
             Server server, ClassLoader commonLibCL,
-            File[] commonLibCLPaths, Map<String, String> args) throws IOException {
+            Map<String, String> args) throws IOException {
         this.server = server;
 //        this.args = args;
         this.hostConfigs = new Hashtable<>();
@@ -42,8 +42,7 @@ public class HostGroup {
         File webappsDir = Option.WEBAPPS_DIR.get(args);
 
         // If host mode
-        initHost(webappsDir, DEFAULT_HOSTNAME, commonLibCL,
-                commonLibCLPaths, args);
+        initHost(webappsDir, DEFAULT_HOSTNAME, commonLibCL, args);
         this.defaultHostName = DEFAULT_HOSTNAME;
         Logger.log(Logger.DEBUG, Launcher.RESOURCES, "HostGroup.InitSingleComplete",
                 this.hostConfigs.size() + "", this.hostConfigs.keySet() + "");
@@ -61,10 +60,10 @@ public class HostGroup {
 
     protected void initHost(File webappsDir, String hostname,
                             ClassLoader commonLibCL,
-                            File[] commonLibCLPaths, Map<String, String> args) throws IOException {
+                            Map<String, String> args) throws IOException {
         Logger.log(Logger.DEBUG, Launcher.RESOURCES, "HostGroup.DeployingHost", hostname);
         HostConfiguration config = new HostConfiguration(server, hostname, commonLibCL,
-                commonLibCLPaths, args, webappsDir);
+                args, webappsDir);
         this.hostConfigs.put(hostname, config);
     }
 }

--- a/src/main/java/winstone/Launcher.java
+++ b/src/main/java/winstone/Launcher.java
@@ -91,7 +91,6 @@ public class Launcher implements Runnable {
 
             // Check for java home
             List<URL> jars = new ArrayList<>();
-            List<File> commonLibCLPaths = new ArrayList<>();
             String defaultJavaHome = System.getProperty("java.home");
             File javaHome = Option.JAVA_HOME.get(args,new File(defaultJavaHome));
             Logger.log(Logger.DEBUG, RESOURCES, "Launcher.UsingJavaHome", javaHome.getPath());
@@ -112,7 +111,6 @@ public class Launcher implements Runnable {
             // Add tools jar to classloader path
             if (toolsJar.exists()) {
                 jars.add(toolsJar.toURI().toURL());
-                commonLibCLPaths.add(toolsJar);
                 Logger.log(Logger.DEBUG, RESOURCES, "Launcher.AddedCommonLibJar",
                         toolsJar.getName());
             } else if (Option.USE_JASPER.get(args))
@@ -129,7 +127,6 @@ public class Launcher implements Runnable {
                         if (aChildren.getName().endsWith(".jar")
                                 || aChildren.getName().endsWith(".zip")) {
                             jars.add(aChildren.toURI().toURL());
-                            commonLibCLPaths.add(aChildren);
                             Logger.log(Logger.DEBUG, RESOURCES, "Launcher.AddedCommonLibJar",
                                     aChildren.getName());
                         }
@@ -154,8 +151,6 @@ public class Launcher implements Runnable {
 
             Logger.log(Logger.MAX, RESOURCES, "Launcher.CLClassLoader",
                     commonLibCL.toString());
-            Logger.log(Logger.MAX, RESOURCES, "Launcher.CLClassLoader",
-                    commonLibCLPaths.toString());
 
 
             if(!extraJars.isEmpty()){
@@ -176,8 +171,7 @@ public class Launcher implements Runnable {
 
 
             // Open the web apps
-            this.hostGroup = new HostGroup(server, commonLibCL,
-                    commonLibCLPaths.toArray(new File[0]), args);
+            this.hostGroup = new HostGroup(server, commonLibCL, args);
 
             List<Connector> connectors = new ArrayList<>();
             // Create connectors (http, https and ajp)


### PR DESCRIPTION
I could find no references to `commonLibCLPaths` [anywhere in the Jenkins ecosystem](https://github.com/search?type=Code&q=user%3Ajenkinsci+commonLibCLPaths`), let alone in this repository. If you look at the deleted code, we are just populating this array and never consuming it, so it is dead code. I could find no usages of the `HostConfiguration` or `HostGroup` constructors outside of this repository, either. This dead code seems best left in the rear-view mirror.