### PR TITLE
[JENKINS-66745] Winstone: http/2 port not backward compatible with ALPN http/1.1 clients

### DIFF
--- a/src/main/java/winstone/Http2ConnectorFactory.java
+++ b/src/main/java/winstone/Http2ConnectorFactory.java
@@ -69,7 +69,9 @@ public class Http2ConnectorFactory extends AbstractSecuredConnectorFactory imple
             // HTTP/2 Connection Factory
             HTTP2ServerConnectionFactory h2 = new HTTP2ServerConnectionFactory(https_config);
             ALPNServerConnectionFactory alpn = new ALPNServerConnectionFactory();
-            alpn.setDefaultProtocol("h2");
+
+            // fallback to http/1.1 for pre-ALPN clients
+            alpn.setDefaultProtocol("http/1.1");
 
             // SSL Connection Factory
             SslConnectionFactory ssl = new SslConnectionFactory(sslContextFactory,alpn.getProtocol());


### PR DESCRIPTION
see [JENKINS-66745](https://issues.jenkins.io/browse/JENKINS-66745)

<!-- Please describe your pull request here. -->
Simple fix -- tweak the default protocol, presumed when ALPN header is not sent, to be http/1.1 -- this allows pre-ALPN clients like curl/wget on RH7 boxes, to properly access the http/2 port in Winstone.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
