### PR TITLE
Make test less flaky

### DIFF
--- a/src/test/java/winstone/accesslog/SimpleAccessLoggerTest.java
+++ b/src/test/java/winstone/accesslog/SimpleAccessLoggerTest.java
@@ -40,6 +40,7 @@ public class SimpleAccessLoggerTest extends AbstractWinstoneTest {
         makeRequest("http://localhost:"+port+"/examples/CountRequestsServlet");
 
         // check the log file
+        Thread.sleep(5000);
         String text = FileUtils.readFileToString(logFile, StandardCharsets.UTF_8);
         assertEquals(String.format("127.0.0.1 - - GET /examples/CountRequestsServlet HTTP/1.1 200%n"),text);
     }


### PR DESCRIPTION
Before adding this sleep, this test would flake about half the time as in [this run](https://ci.jenkins.io/job/Core/job/winstone/job/master/252/testReport/winstone.accesslog/SimpleAccessLoggerTest/testSimpleConnection/). After adding this sleep I have run the test 10 times in a row without any flakes.