### PR TITLE
Remove ability to load pem cert for winstone

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,6 @@ To run different web applications for diffent virtual hosts:
        --httpsKeyStore          = the location of the SSL KeyStore file. Default is ./winstone.ks
        --httpsKeyStorePassword  = the password for the SSL KeyStore file. Default is null
        --httpsKeyManagerType    = the SSL KeyManagerFactory type (eg SunX509, IbmX509). Default is SunX509
-       --httpsPrivateKey        = this switch with --httpsCertificate can be used to run HTTPS with OpenSSL secret key
-         / --httpsCertificate     file and the corresponding certificate file
        --httpsRedirectHttp      = redirect http requests to https (requires both --httpPort and --httpsPort)
        --http2Port              = set the http2 listening port. -1 to disable, Default is disabled
        --http2ListenAddress     = set the http2 listening address. Default is all interfaces

--- a/src/main/java/winstone/AbstractSecuredConnectorFactory.java
+++ b/src/main/java/winstone/AbstractSecuredConnectorFactory.java
@@ -12,30 +12,16 @@ import org.eclipse.jetty.util.ssl.SslContextFactory;
 import winstone.cmdline.Option;
 
 import javax.net.ssl.KeyManagerFactory;
-import java.io.BufferedReader;
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.lang.reflect.Method;
-import java.math.BigInteger;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.InvalidPathException;
 import java.security.GeneralSecurityException;
-import java.security.KeyFactory;
 import java.security.KeyStore;
-import java.security.PrivateKey;
-import java.security.cert.Certificate;
-import java.security.cert.CertificateFactory;
-import java.security.spec.RSAPrivateKeySpec;
 import java.text.MessageFormat;
 import java.util.Arrays;
-import java.util.Base64;
 import java.util.Enumeration;
 import java.util.Map;
-import java.util.logging.Level;
 
 /**
  *

--- a/src/main/java/winstone/cmdline/Option.java
+++ b/src/main/java/winstone/cmdline/Option.java
@@ -67,9 +67,7 @@ public class Option<T> {
     public static final OString HTTPS_PRIVATE_KEY_PASSWORD=string("httpsPrivateKeyPassword");
     public static final OString HTTPS_KEY_MANAGER_TYPE=string("httpsKeyManagerType","SunX509");
     public static final OBoolean HTTPS_VERIFY_CLIENT=bool("httpsVerifyClient",false);
-    public static final OFile HTTPS_CERTIFICATE=file("httpsCertificate");
     public static final OString HTTPS_CERTIFICATE_ALIAS=string("httpsCertificateAlias");
-    public static final OFile HTTPS_PRIVATE_KEY=file("httpsPrivateKey");
     public static final OString HTTPS_EXCLUDE_CIPHER_SUITES=string("excludeCipherSuites");
     public static final OBoolean HTTPS_REDIRECT_HTTP=bool("httpsRedirectHttp", false);
 

--- a/src/main/resources/winstone/LocalStrings.properties
+++ b/src/main/resources/winstone/LocalStrings.properties
@@ -94,8 +94,6 @@ Launcher.UsageInstructions.Options=\
 \   --httpsKeyStore          = the location of the SSL KeyStore file. Default is ./winstone.ks\n\
 \   --httpsKeyStorePassword  = the password for the SSL KeyStore file. Default is null\n\
 \   --httpsKeyManagerType    = the SSL KeyManagerFactory type (eg SunX509, IbmX509). Default is SunX509\n\
-\   --httpsPrivateKey        = this switch with --httpsCertificate can be used to run HTTPS with OpenSSL secret key\n\
-\     / --httpsCertificate     file and the corresponding certificate file\n\
 \   --httpsRedirectHttp      = redirect http requests to https (requires both --httpPort and --httpsPort)\n\
 \   --http2Port              = set the http2 listening port. -1 to disable, Default is disabled\n\
 \   --http2ListenAddress     = set the http2 listening address. Default is all interfaces\n\
@@ -168,9 +166,6 @@ HttpsConnectorFactory.SelfSigned=\
   Creating a self-signed certificate currently relies on unsupported APIs in the Oracle JRE.\n\
   Please create your own certificate using supported tools instead and use --httpsKeyStore.
 HttpsConnectorFactory.SelfSignedError=Failed to create a self-signed certificate; make one yourself.
-HttpsConnectorFactory.LoadPrivateKey=\
-  Using the --httpsPrivateKey/--httpsCertificate options currently relies on unsupported APIs in the Oracle JRE.\n\
-  Please use --httpsKeyStore and related options instead.
 HttpsConnectorFactory.LoadPrivateKeyError=Cannot load private key; try using a Java keystore instead.
 
 Http2ConnectorFactory.FailedStart.ALPN=Failed to start ALPN

--- a/src/main/resources/winstone/LocalStrings.properties
+++ b/src/main/resources/winstone/LocalStrings.properties
@@ -166,7 +166,6 @@ HttpsConnectorFactory.SelfSigned=\
   Creating a self-signed certificate currently relies on unsupported APIs in the Oracle JRE.\n\
   Please create your own certificate using supported tools instead and use --httpsKeyStore.
 HttpsConnectorFactory.SelfSignedError=Failed to create a self-signed certificate; make one yourself.
-HttpsConnectorFactory.LoadPrivateKeyError=Cannot load private key; try using a Java keystore instead.
 
 Http2ConnectorFactory.FailedStart.ALPN=Failed to start ALPN
 

--- a/src/test/java/winstone/HttpsConnectorFactoryTest.java
+++ b/src/test/java/winstone/HttpsConnectorFactoryTest.java
@@ -53,7 +53,12 @@ public class HttpsConnectorFactoryTest extends AbstractWinstoneTest {
         args.put("httpsKeyStorePassword", "changeit");
         winstone = new Launcher(args);
         int port = (( ServerConnector)winstone.server.getConnectors()[0]).getLocalPort();
+        assertConnectionRefused("127.0.0.2", port);
         request(new TrustEveryoneManager(), port);
+        LowResourceMonitor lowResourceMonitor = winstone.server.getBean( LowResourceMonitor.class);
+        assertNotNull(lowResourceMonitor);
+        assertFalse(lowResourceMonitor.isLowOnResources());
+        assertTrue(lowResourceMonitor.isAcceptingInLowResources());
     }
 
     @Test

--- a/src/test/java/winstone/HttpsConnectorFactoryTest.java
+++ b/src/test/java/winstone/HttpsConnectorFactoryTest.java
@@ -9,7 +9,6 @@ import org.apache.commons.io.IOUtils;
 import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.LowResourceMonitor;
 import org.eclipse.jetty.server.ServerConnector;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import javax.net.ssl.HttpsURLConnection;

--- a/src/test/java/winstone/HttpsConnectorFactoryTest.java
+++ b/src/test/java/winstone/HttpsConnectorFactoryTest.java
@@ -30,29 +30,6 @@ import org.jvnet.hudson.test.Issue;
  * @author Kohsuke Kawaguchi
  */
 public class HttpsConnectorFactoryTest extends AbstractWinstoneTest {
-    @Test
-    @Ignore("TODO re-implement with a key store")
-    public void testHttps() throws Exception {
-        Map<String,String> args = new HashMap<>();
-        args.put("warfile", "target/test-classes/test.war");
-        args.put("prefix", "/");
-        args.put("httpPort", "-1");
-        args.put("httpsPort", "0");
-        args.put("httpsListenAddress", "localhost");
-        args.put("httpsPrivateKey", "src/ssl/server.key");
-        args.put("httpsCertificate", "src/ssl/server.crt");
-        winstone = new Launcher(args);
-        int port = ((ServerConnector)winstone.server.getConnectors()[0]).getLocalPort();
-
-        assertConnectionRefused("127.0.0.2", port);
-
-        request(new TrustManagerImpl(), port);
-
-        LowResourceMonitor lowResourceMonitor = winstone.server.getBean( LowResourceMonitor.class);
-        assertNotNull(lowResourceMonitor);
-        assertFalse(lowResourceMonitor.isLowOnResources());
-        assertTrue(lowResourceMonitor.isAcceptingInLowResources());
-    }
 
     private void request(X509TrustManager tm, int port) throws Exception {
         HttpsURLConnection con = (HttpsURLConnection)new URL("https://localhost:"+port+"/CountRequestsServlet").openConnection();

--- a/src/test/java/winstone/HttpsConnectorFactoryTest.java
+++ b/src/test/java/winstone/HttpsConnectorFactoryTest.java
@@ -9,6 +9,7 @@ import org.apache.commons.io.IOUtils;
 import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.LowResourceMonitor;
 import org.eclipse.jetty.server.ServerConnector;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import javax.net.ssl.HttpsURLConnection;
@@ -30,6 +31,7 @@ import org.jvnet.hudson.test.Issue;
  */
 public class HttpsConnectorFactoryTest extends AbstractWinstoneTest {
     @Test
+    @Ignore("TODO re-implement with a key store")
     public void testHttps() throws Exception {
         Map<String,String> args = new HashMap<>();
         args.put("warfile", "target/test-classes/test.war");


### PR DESCRIPTION
Fixes https://github.com/jenkinsci/winstone/issues/213

Test needs re-implementing to use a keystore (that mode wasn't tested before afaict)

## Upgrade guidelines

Support has been removed for PEM encoded certificates when running Jenkins with the embedded Jetty (winstone) container and TLS.
Specifically the flags `--httpsPrivateKey` and `--httpsCertificate` have been removed.

Users who were previously using this feature must use a KeyStore instead.  See the [documentation](https://www.jenkins.io/doc/book/installing/initial-settings/#https-with-an-existing-certificate) for details.

This feature has been logging deprecation warnings on startup since 2016.