### PR TITLE
Update `README`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # What is Winstone?
-Winstone is a command line interface around Jetty 9.4, which implements
-servlet 3.1, WebSocket/JSR-356, and HTTP/2 support. It is used as the default
+Winstone is a command line interface around Jetty 10.0.x, which implements
+Servlet 4.0 (JakartaEE 8/`javax.servlet.*`), WebSocket/JSR-356, and HTTP/2 support. It is used as the default
 embedded servlet container in Jenkins (via [executable-war](https://github.com/jenkinsci/extras-executable-war) module)
 and can be used by any other web applications that wants to be self-contained.
 
@@ -52,7 +52,7 @@ To run different web applications for diffent virtual hosts:
 
 ## Command-line options
 
-    Winstone Servlet Engine v4.0, (c) 2003-2006 Rick Knowles
+    Winstone Servlet Engine, (c) 2003-2006 Rick Knowles
     Usage: java winstone.jar [--option=value] [--option=value] [etc]
     
     Required options: either --webroot OR --warfile OR --webappsDir OR --hostsDir
@@ -105,6 +105,8 @@ To run different web applications for diffent virtual hosts:
        --sessionEviction        = set the session eviction timeout for idle sessions in seconds. Default value is 180. -1 never evict, 0 evict on exit
        --mimeTypes=ARG          = define additional MIME type mappings. ARG would be EXT=MIMETYPE:EXT=MIMETYPE:...
                                   (e.g., xls=application/vnd.ms-excel:wmf=application/x-msmetafile)
+       --requestHeaderSize=N    = set the maximum size in bytes of the request header. Default is 8192.
+       --responseHeaderSize=N   = set the maximum size in bytes of the response header. Default is 8192.
        --maxParamCount=N        = set the max number of parameters allowed in a form submission to protect
                                   against hash DoS attack (oCERT #2011-003). Default is 10000.
        --useJmx                 = Enable Jetty Jmx


### PR DESCRIPTION
Noticed a number of problems with the README:

- Stale references to Jetty 9.x and Servlet 3.x
- Stale reference to Winstone 4.0
- Missing documentation for `--requestHeaderSize` and `--responseHeaderSize`.

This PR corrects these problems by updating the references to Jetty and Servlet API as per [the Jetty home page](https://www.eclipse.org/jetty/). It also makes the command-line options section of the `README` consistent with what is printed when you run `java -jar winstone.jar --help`.