### PR TITLE
Improve comment and error message

### DIFF
--- a/src/main/java/winstone/HostConfiguration.java
+++ b/src/main/java/winstone/HostConfiguration.java
@@ -281,9 +281,9 @@ public class HostConfiguration {
                     // If archive date is newer than unzipped file, overwrite
                     File outFile = new File(unzippedDir, elemName);
 
-                    // Fix Zip Slip vulnerability
+                    // Protect against Zip Slip attack
                     if (!outFile.toPath().normalize().startsWith(unzippedDir.toPath().normalize())) {
-                        throw new IOException("Bad zip entry");
+                        throw new IOException("Bad zip entry: " + elemName);
                     }
 
                     if (outFile.exists() && (outFile.lastModified() > warfile.lastModified())) {

--- a/src/main/java/winstone/HostConfiguration.java
+++ b/src/main/java/winstone/HostConfiguration.java
@@ -281,7 +281,7 @@ public class HostConfiguration {
                     // If archive date is newer than unzipped file, overwrite
                     File outFile = new File(unzippedDir, elemName);
 
-                    // Protect against Zip Slip attack
+                    // Disallow unzipping files outside the target dir
                     if (!outFile.toPath().normalize().startsWith(unzippedDir.toPath().normalize())) {
                         throw new IOException("Bad zip entry: " + elemName);
                     }


### PR DESCRIPTION
Improve the comment from #246 to more accurately reflect what the code is doing, and improve the error message to state the name of the problematic entry when the condition is encountered.

CC @JLLeitschuh @daniel-beck