### PR TITLE
Remove redundant `project.build.sourceEncoding` property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,6 @@
     <!-- TODO: remove once SpotBugs issues are fixed. 29 so far -->
     <spotbugs.threshold>High</spotbugs.threshold>
     <gitHubRepo>jenkinsci/winstone</gitHubRepo>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
   <licenses>


### PR DESCRIPTION
This has been in the parent POM since https://github.com/jenkinsci/pom/pull/257 which was released in 1.76.