### PR TITLE
Remove redundant version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,6 @@
 
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>3.3.0</version>
         <configuration>
           <archive>
             <manifest>


### PR DESCRIPTION
The version here is redundant, as it is specified in [the parent POM](https://github.com/jenkinsci/pom/blob/8992541180d91c628488f94db69b5ebcc7e97062/pom.xml#L140). Additionally, duplicating it here results in undesirable Dependabot spam. By removing the explicit and redundant version number, we reduce both unnecessary duplication and Dependabot spam.