### PR TITLE
Remove unneeded SUREFIRE-1226 workaround

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,6 @@
 <!--          <systemPropertyVariables>-->
 <!--            <java.util.logging.config.file>src/test/resources/jul.properties</java.util.logging.config.file>-->
 <!--          </systemPropertyVariables>-->
-          <trimStackTrace>false</trimStackTrace> <!-- SUREFIRE-1226 workaround -->
         </configuration>
       </plugin>
 


### PR DESCRIPTION
Like https://github.com/jenkinsci/plugin-pom/pull/534, but for Winstone, which has been on Surefire 3.0.0-M7 since #225.