### PR TITLE
Upgrade Rhino from 1.7R2 to 1.7R5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -238,9 +238,9 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>rhino</groupId>
-      <artifactId>js</artifactId>
-      <version>1.7R2</version>
+      <groupId>org.mozilla</groupId>
+      <artifactId>rhino</artifactId>
+      <version>1.7R5</version>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
Newer versions of Rhino are not compatible with [HttpUnit](http://httpunit.sourceforge.net/).