### PR TITLE
Remove redundant `maven-antrun-plugin` version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-antrun-plugin</artifactId>
-        <version>3.1.0</version>
         <executions>
           <execution>
             <id>prepare-testwebapp</id>


### PR DESCRIPTION
The version here is redundant, as it is specified in [the parent POM](https://github.com/jenkinsci/pom/blob/8992541180d91c628488f94db69b5ebcc7e97062/pom.xml#L125). Additionally, duplicating it here results in undesirable Dependabot spam. By removing the explicit and redundant version number, we reduce both unnecessary duplication and Dependabot spam.