### PR TITLE
Drop `commons-io` dependency in favor of native Java Platform functionality

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -207,13 +207,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-      <version>2.11.0</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/src/test/java/winstone/AbstractWinstoneTest.java
+++ b/src/test/java/winstone/AbstractWinstoneTest.java
@@ -7,7 +7,6 @@ import com.meterware.httpunit.GetMethodWebRequest;
 import com.meterware.httpunit.WebConversation;
 import com.meterware.httpunit.WebRequest;
 import com.meterware.httpunit.WebResponse;
-import org.apache.commons.io.IOUtils;
 import org.junit.After;
 import org.xml.sax.SAXException;
 
@@ -35,7 +34,7 @@ public class AbstractWinstoneTest {
         WebResponse wresp = wc.getResponse(wreq);
         InputStream content = wresp.getInputStream();
         assertTrue("Loading CountRequestsServlet", content.available() > 0);
-        String s = IOUtils.toString(content, StandardCharsets.UTF_8);
+        String s = new String(content.readAllBytes(), StandardCharsets.UTF_8);
         content.close();
         return s;
     }

--- a/src/test/java/winstone/FormSubmissionTest.java
+++ b/src/test/java/winstone/FormSubmissionTest.java
@@ -10,7 +10,6 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
-import org.apache.commons.io.IOUtils;
 
 import org.eclipse.jetty.server.ServerConnector;
 import org.junit.Test;
@@ -38,7 +37,7 @@ public class FormSubmissionTest extends AbstractWinstoneTest {
             WebResponse wresp = wc.getResponse(wreq);
             try (InputStream content = wresp.getInputStream()) {
                 assertTrue("Loading AcceptFormServlet at size " + size, content.available() > 0);
-                assertEquals("correct response at size " + size, "received " + (size + "x=".length()) + " bytes", IOUtils.toString(content, StandardCharsets.US_ASCII));
+                assertEquals("correct response at size " + size, "received " + (size + "x=".length()) + " bytes", new String(content.readAllBytes(), StandardCharsets.US_ASCII));
             }
         }
     }

--- a/src/test/java/winstone/HttpsConnectorFactoryTest.java
+++ b/src/test/java/winstone/HttpsConnectorFactoryTest.java
@@ -4,9 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
-import org.apache.commons.io.IOUtils;
 import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.LowResourceMonitor;
 import org.eclipse.jetty.server.ServerConnector;
@@ -14,7 +12,6 @@ import org.junit.Test;
 
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.X509TrustManager;
 import java.net.HttpURLConnection;
 import java.net.URL;
@@ -38,7 +35,7 @@ public class HttpsConnectorFactoryTest extends AbstractWinstoneTest {
         SSLContext ssl = SSLContext.getInstance("SSL");
         ssl.init(null, new X509TrustManager[] {tm}, null);
         con.setSSLSocketFactory(ssl.getSocketFactory());
-        IOUtils.toString(con.getInputStream(), StandardCharsets.UTF_8);
+        new String(con.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
     }
     
     @Issue("JENKINS-60857")
@@ -106,7 +103,7 @@ public class HttpsConnectorFactoryTest extends AbstractWinstoneTest {
         SSLContext ssl = SSLContext.getInstance("SSL");
         ssl.init(null, new X509TrustManager[] {tm}, null);
         secureCon.setSSLSocketFactory(ssl.getSocketFactory());
-        IOUtils.toString(secureCon.getInputStream(), StandardCharsets.UTF_8);
+        new String(secureCon.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
     }
 
 }

--- a/src/test/java/winstone/accesslog/SimpleAccessLoggerTest.java
+++ b/src/test/java/winstone/accesslog/SimpleAccessLoggerTest.java
@@ -2,15 +2,15 @@ package winstone.accesslog;
 
 import static org.junit.Assert.assertEquals;
 
-import org.apache.commons.io.FileUtils;
 import org.eclipse.jetty.server.ServerConnector;
 import org.junit.Test;
 import winstone.AbstractWinstoneTest;
 import winstone.Launcher;
 
-import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -23,8 +23,8 @@ public class SimpleAccessLoggerTest extends AbstractWinstoneTest {
      */
     @Test
     public void testSimpleConnection() throws Exception {
-        File logFile = new File("target/test.log");
-        Files.deleteIfExists(logFile.toPath());
+        Path logFile = Paths.get("target/test.log");
+        Files.deleteIfExists(logFile);
 
         // Initialise container
         Map<String,String> args = new HashMap<>();
@@ -32,7 +32,7 @@ public class SimpleAccessLoggerTest extends AbstractWinstoneTest {
         args.put("prefix", "/examples");
         args.put("httpPort", "0");
         args.put("accessLoggerClassName",SimpleAccessLogger.class.getName());
-        args.put("simpleAccessLogger.file",logFile.getAbsolutePath());
+        args.put("simpleAccessLogger.file",logFile.toAbsolutePath().toString());
         args.put("simpleAccessLogger.format","###ip### - ###user### ###uriLine### ###status###");
         winstone = new Launcher(args);
         int port = ((ServerConnector)winstone.server.getConnectors()[0]).getLocalPort();
@@ -44,7 +44,7 @@ public class SimpleAccessLoggerTest extends AbstractWinstoneTest {
         String text = "";
         for(int i=0; i < 50; ++i) {
             Thread.sleep(100);
-            text = FileUtils.readFileToString(logFile, StandardCharsets.UTF_8);
+            text = Files.readString(logFile, StandardCharsets.UTF_8);
             if (!"".equals(text))
                 break;
         }


### PR DESCRIPTION
Drops usages of the Apache Commons I/O library in tests in favor of native Java Platform functionality. It is generally desirable to have fewer dependencies, because that reduces the risk of problems when upgrading dependencies or using outdated versions.