### PR TITLE
Manage both SLF4J API and SLF4J implementation versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
     <changelist>-SNAPSHOT</changelist>
     <jetty.version>10.0.12</jetty.version>
     <alpn.api.version>1.1.3.v20160715</alpn.api.version>
+    <slf4j.version>2.0.0</slf4j.version>
     <spotbugs.excludeFilterFile>src/spotbugs/spotbugs-excludes.xml</spotbugs.excludeFilterFile>
     <gitHubRepo>jenkinsci/winstone</gitHubRepo>
   </properties>
@@ -201,6 +202,17 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <!-- TODO SLF4J-437 use BOM -->
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+        <version>${slf4j.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-jdk14</artifactId>
+        <version>${slf4j.version}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -281,7 +293,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-jdk14</artifactId>
-      <version>2.0.0</version>
+      <version>${slf4j.version}</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -293,7 +293,6 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-jdk14</artifactId>
-      <version>${slf4j.version}</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
### Problem

Jetty depends on `org.slf4j:slf4j-api` without providing an implementation, which forces us to provide one by depending on `org.slf4j:slf4j-jdk14`. Since pending [SLF4J-437](https://jira.qos.ch/browse/SLF4J-437) SLF4J provides no BOM, this creates challenges for Dependabot updates as seen in https://github.com/jenkinsci/winstone/pull/235#pullrequestreview-1017970886: Dependabot's update to the version of `slf4j-jdk14` creates an Enforcer error with the version of `slf4j-api` that Jetty depends on.

### Solution

Pending SLF4J-437, manage both `slf4j-api` and `slf4j-jdk14` in a `<dependencyManagement>` section whose version is controlled by a single Maven property. When Dependabot updates this property, the managed dependencies for both the API and implementation get updated, and the Enforcer error will no longer occur.

### Testing done

Compared the contents of `winstone.jar` before and after this PR. They were identical.

Also tested a potential future Dependabot update by bumping this from 2.0.0 to 2.0.1 and verified that the Enforcer error mentioned above no longer occurred.