### PR TITLE
Prefer `assertThrows` to try/fail/catch

### DIFF
--- a/src/test/java/winstone/AbstractWinstoneTest.java
+++ b/src/test/java/winstone/AbstractWinstoneTest.java
@@ -1,7 +1,7 @@
 package winstone;
 
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import com.meterware.httpunit.GetMethodWebRequest;
 import com.meterware.httpunit.WebConversation;
@@ -39,11 +39,11 @@ public class AbstractWinstoneTest {
         return s;
     }
 
-    protected void assertConnectionRefused(String host, int port) throws IOException {
-        try (Socket s = new Socket(host,port)) {
-            fail("shouldn't be listening on 127.0.0.1");
-        } catch (ConnectException e) {
-            // expected
-        }
+    protected void assertConnectionRefused(String host, int port) {
+        assertThrows(ConnectException.class, () -> {
+            try (Socket s = new Socket(host, port)) {
+                // shouldn't be listening on 127.0.0.1
+            }
+        });
     }
 }

--- a/src/test/java/winstone/realm/ArgumentsRealmTest.java
+++ b/src/test/java/winstone/realm/ArgumentsRealmTest.java
@@ -1,7 +1,7 @@
 package winstone.realm;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertThrows;
 
 import com.meterware.httpunit.AuthorizationRequiredException;
 import org.eclipse.jetty.server.ServerConnector;
@@ -26,13 +26,7 @@ public class ArgumentsRealmTest extends AbstractWinstoneTest {
         args.put("argumentsRealm.roles.joe","loginUser");
         winstone = new Launcher(args);
         int port = ((ServerConnector)winstone.server.getConnectors()[0]).getLocalPort();
-        try {
-            makeRequest("http://localhost:"+port+"/secure/secret.txt");
-
-            fail("should require authentication");
-        } catch (AuthorizationRequiredException e) {
-            // expected
-        }
+        assertThrows(AuthorizationRequiredException.class, () -> makeRequest("http://localhost:" + port + "/secure/secret.txt"));
 
         wc.setAuthorization("joe","eoj");
         assertEquals("diamond", makeRequest("http://localhost:"+port+"/secure/secret.txt"));


### PR DESCRIPTION
Like https://github.com/jenkinsci/jenkins/pull/7114. Some test cleanup, mainly eliminating usages of try/fail/catch in favor of the more legible alternative offered by JUnit 4.13 in the form of `Assert#assertThrows`.