### PR TITLE
Migrate from HttpUnit to native Java Platform functionality

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -224,25 +224,6 @@
     </dependency>
 
     <dependency>
-      <groupId>httpunit</groupId>
-      <artifactId>httpunit</artifactId>
-      <version>1.7</version>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>javax.servlet</groupId>
-          <artifactId>servlet-api</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.mozilla</groupId>
-      <artifactId>rhino</artifactId>
-      <version>1.7R5</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
     </dependency>

--- a/src/test/java/winstone/HttpConnectorFactoryTest.java
+++ b/src/test/java/winstone/HttpConnectorFactoryTest.java
@@ -43,7 +43,9 @@ public class HttpConnectorFactoryTest extends AbstractWinstoneTest {
         int port = ((ServerConnector)winstone.server.getConnectors()[0]).getLocalPort();
         assertConnectionRefused("127.0.0.1",port);
 
-        makeRequest("http://127.0.0.2:"+port+"/CountRequestsServlet");
+        assertEquals(
+                "<html><body>This servlet has been accessed via GET 1001 times</body></html>\r\n",
+                makeRequest("http://127.0.0.2:" + port + "/CountRequestsServlet"));
 
         LowResourceMonitor lowResourceMonitor = winstone.server.getBean(LowResourceMonitor.class);
         assertNotNull(lowResourceMonitor);

--- a/src/test/java/winstone/LauncherTest.java
+++ b/src/test/java/winstone/LauncherTest.java
@@ -2,10 +2,14 @@ package winstone;
 
 import static org.junit.Assert.assertEquals;
 
-import com.meterware.httpunit.WebResponse;
 import org.eclipse.jetty.server.ServerConnector;
 import org.junit.Test;
 
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -22,9 +26,13 @@ public class LauncherTest extends AbstractWinstoneTest {
         args.put("mimeTypes", "xxx=text/xxx");
         winstone = new Launcher(args);
         int port = ((ServerConnector)winstone.server.getConnectors()[0]).getLocalPort();
-        WebResponse r = wc.getResponse("http://127.0.0.2:"+port+"/test.xxx");
-        assertEquals("text/xxx",r.getContentType());
-        assertEquals("Hello",r.getText());
+        HttpRequest request =
+                HttpRequest.newBuilder(new URI("http://127.0.0.2:" + port + "/test.xxx")).GET().build();
+        HttpResponse<String> response =
+                HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
+        assertEquals(HttpURLConnection.HTTP_OK, response.statusCode());
+        assertEquals("text/xxx", response.headers().firstValue("Content-Type").get());
+        assertEquals("Hello", response.body());
     }
 
 }

--- a/src/test/java/winstone/accesslog/SimpleAccessLoggerTest.java
+++ b/src/test/java/winstone/accesslog/SimpleAccessLoggerTest.java
@@ -37,7 +37,9 @@ public class SimpleAccessLoggerTest extends AbstractWinstoneTest {
         winstone = new Launcher(args);
         int port = ((ServerConnector)winstone.server.getConnectors()[0]).getLocalPort();
         // make a request
-        makeRequest("http://localhost:"+port+"/examples/CountRequestsServlet");
+        assertEquals(
+                "<html><body>This servlet has been accessed via GET 1001 times</body></html>\r\n",
+                makeRequest("http://localhost:" + port + "/examples/CountRequestsServlet"));
 
         // check the log file
         // check the log file every 100ms for 5s

--- a/src/test/java/winstone/realm/ArgumentsRealmTest.java
+++ b/src/test/java/winstone/realm/ArgumentsRealmTest.java
@@ -1,14 +1,20 @@
 package winstone.realm;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertNotEquals;
 
-import com.meterware.httpunit.AuthorizationRequiredException;
 import org.eclipse.jetty.server.ServerConnector;
 import org.junit.Test;
 import winstone.AbstractWinstoneTest;
 import winstone.Launcher;
 
+import java.net.Authenticator;
+import java.net.HttpURLConnection;
+import java.net.PasswordAuthentication;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -26,9 +32,21 @@ public class ArgumentsRealmTest extends AbstractWinstoneTest {
         args.put("argumentsRealm.roles.joe","loginUser");
         winstone = new Launcher(args);
         int port = ((ServerConnector)winstone.server.getConnectors()[0]).getLocalPort();
-        assertThrows(AuthorizationRequiredException.class, () -> makeRequest("http://localhost:" + port + "/secure/secret.txt"));
+        HttpRequest request =
+                HttpRequest.newBuilder(new URI("http://localhost:" + port + "/secure/secret.txt")).GET().build();
+        HttpResponse<String> response =
+                HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
+        assertEquals(HttpURLConnection.HTTP_UNAUTHORIZED, response.statusCode());
+        assertNotEquals("diamond", response.body());
 
-        wc.setAuthorization("joe","eoj");
-        assertEquals("diamond", makeRequest("http://localhost:"+port+"/secure/secret.txt"));
+        HttpClient client = HttpClient.newBuilder().authenticator(new Authenticator() {
+            @Override
+            protected PasswordAuthentication getPasswordAuthentication() {
+                return new PasswordAuthentication("joe", "eoj".toCharArray());
+            }
+        }).build();
+        response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        assertEquals(HttpURLConnection.HTTP_OK, response.statusCode());
+        assertEquals("diamond", response.body());
     }
 }

--- a/src/test/java/winstone/testCase/load/LoadTest.java
+++ b/src/test/java/winstone/testCase/load/LoadTest.java
@@ -6,6 +6,7 @@
  */
 package winstone.testCase.load;
 
+import java.net.http.HttpClient;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -16,7 +17,6 @@ import org.junit.Test;
 import winstone.Logger;
 import winstone.WinstoneResourceBundle;
 
-import com.meterware.httpunit.WebConversation;
 import winstone.cmdline.Option;
 
 /**
@@ -24,7 +24,7 @@ import winstone.cmdline.Option;
  * works by hitting a supplied URL with parallel threads (with keep-alives or
  * without) at an escalating rate, and counting the no of failures.
  *
- * It uses HttpUnit's WebConversation class for the connection.
+ * It uses {@link java.net.http.HttpClient} for the connection.
  *
  * @author <a href="mailto:rick_knowles@hotmail.com">Rick Knowles</a>
  * @version $Id: LoadTest.java,v 1.2 2006/02/28 07:32:49 rickknowles Exp $
@@ -63,19 +63,19 @@ public class LoadTest {
 
     @Test
     public void test() throws InterruptedException {
-        WebConversation wc = null;
+        HttpClient client = null;
 
         // Loop through in steps
         for (int n = this.startThreads; n <= this.endThreads; n += this.stepSize) {
             if (this.useKeepAlives)
-                wc = new WebConversation();
+                client = HttpClient.newHttpClient();
 
             // Spawn the threads
             int noOfSeconds = (int) this.stepPeriod / 1000;
             List<LoadTestThread> threads = new ArrayList<>();
             for (int m = 0; m < n; m++)
                 threads.add(new LoadTestThread(this.url, this, this.resources,
-                        wc, noOfSeconds - 1));
+                        client, noOfSeconds - 1));
 
             // Sleep for step period
             Thread.sleep(this.stepPeriod + gracePeriod);


### PR DESCRIPTION
### Problem

The test suite has a dependency on [HttpUnit](http://httpunit.sourceforge.net/), last released in 2008 and which in turn depends on an obsolete version of Rhino. This does not seem sustainable.

### Solution

Migrate to the native HTTP client offered in Java 9+.

## Implementation

Note that `testKeepAliveConnection` appears to have never been completed; in practice, the `WebImage[] img = wresp1.getImages()` line was always returning an empty array, making this test equivalent to `testSimpleConnection`. The commented out lines also appear to indicate that the attempt to finish this test was abandoned. Since this test never worked to begin with and duplicated an existing test, I simply deleted it.

### Testing done

`LoadTest` appears to have been completely broken before this PR, but as of this PR it now works:

```
Sep 18, 2022 2:51:08 PM winstone.Logger logInternal
INFO: Load test initialised with properties: URL=http://127.0.0.1, KeepAlives=true, StartThreads=20, EndThreads=1000, StepSize=20, StepPeriod=5000, GracePeriod=5000
Sep 18, 2022 2:51:18 PM winstone.Logger logInternal
INFO: n=20, success=100, error=0, averageTime=99ms
Sep 18, 2022 2:51:28 PM winstone.Logger logInternal
INFO: n=40, success=199, error=1, averageTime=18ms
Sep 18, 2022 2:51:38 PM winstone.Logger logInternal
INFO: n=60, success=298, error=2, averageTime=18ms
```