### PR TITLE
Run tests with JUnit Jupiter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -218,8 +218,13 @@
 
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
This doesn't convert tests to JUnit 5, but it does add support for JUnit 5 in the test suite, and it runs the existing JUnit 4 based tests using the JUnit 5 Vintage engine, consistent with the way we now run tests in Jenkins core and plugins.