### PR TITLE
Exclude SpotBugs annotations from shaded JAR

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,11 @@
               </excludes>
             </filter>
           </filters>
+          <artifactSet>
+            <excludes>
+              <exclude>com.github.spotbugs:spotbugs-annotations</exclude>
+            </excludes>
+          </artifactSet>
           <!-- Jetty uses reflection in various places and that breaks relocation
           <relocations>
             <relocation>


### PR DESCRIPTION
I noticed `Including com.github.spotbugs:spotbugs-annotations:jar:4.7.2 in the shaded jar` when doing a build recently. We don't need the SpotBugs annotations at runtime, so this just bloats the build. With this change, the same line in the build now reads `[INFO] Excluding com.github.spotbugs:spotbugs-annotations:jar:4.7.2 from the shaded jar`.