### PR TITLE
Use Java 11 HTTP client in `HttpsConnectorFactoryTest`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,8 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
+          <reuseForks>false</reuseForks>
+          <runOrder>alphabetical</runOrder>
 <!--          Uncomment to enable extra logging for debugging          -->
 <!--          <systemPropertyVariables>-->
 <!--            <java.util.logging.config.file>src/test/resources/jul.properties</java.util.logging.config.file>-->


### PR DESCRIPTION
`HttpsConnectorFactoryTest` was using `HttpsURLConnection` to do its testing, which is inconsistent with all other tests that use the Java 11 HTTP client. This PR adapts that test to be consistent with all the other tests by using the Java 11 HTTP client.

While `HttpsURLConnection` could be instructed to disable hostname verification programmatically on a per-connection basis, it was a deliberate decision to not add a hostname verifier API to the Java 11 HTTP Client. Strict hostname verification is enabled by default and can only be disabled by setting a global system property. Doing so forces us to disable re-use of forks in Surefire, since tests now manipulate static JVM state that should not be shared with other tests. While we were updating the Surefire configuration, we also set an alphabetical run order to be consistent with core and plugins and to make test runs more deterministic.