### PR TITLE
[JENKINS-69638] HTTP/2 broken after Jetty 10 upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,6 @@
     <revision>6.4</revision>
     <changelist>-SNAPSHOT</changelist>
     <jetty.version>10.0.12</jetty.version>
-    <alpn.api.version>1.1.3.v20160715</alpn.api.version>
     <slf4j.version>2.0.1</slf4j.version>
     <spotbugs.excludeFilterFile>src/spotbugs/spotbugs-excludes.xml</spotbugs.excludeFilterFile>
     <gitHubRepo>jenkinsci/winstone</gitHubRepo>
@@ -70,6 +69,8 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
+          <reuseForks>false</reuseForks>
+          <runOrder>alphabetical</runOrder>
 <!--          Uncomment to enable extra logging for debugging          -->
 <!--          <systemPropertyVariables>-->
 <!--            <java.util.logging.config.file>src/test/resources/jul.properties</java.util.logging.config.file>-->
@@ -240,6 +241,10 @@
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-alpn-java-server</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-alpn-server</artifactId>
     </dependency>
     <dependency>
@@ -261,11 +266,6 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-webapp</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty.alpn</groupId>
-      <artifactId>alpn-api</artifactId>
-      <version>${alpn.api.version}</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.http2</groupId>

--- a/src/main/java/winstone/Http2ConnectorFactory.java
+++ b/src/main/java/winstone/Http2ConnectorFactory.java
@@ -20,8 +20,6 @@
 
 package winstone;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import org.eclipse.jetty.alpn.ALPN;
 import org.eclipse.jetty.alpn.server.ALPNServerConnectionFactory;
 import org.eclipse.jetty.http.HttpCompliance;
 import org.eclipse.jetty.http.UriCompliance;
@@ -47,7 +45,6 @@ import java.util.Map;
  */
 public class Http2ConnectorFactory extends AbstractSecuredConnectorFactory implements ConnectorFactory {
     @Override
-    @SuppressFBWarnings(value = "ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD", justification = "There is only one instance of this connector factory")
     public Connector start( Map<String, String> args, Server server ) throws IOException
     {
         int listenPort = Option.HTTP2_PORT.get( args );
@@ -92,9 +89,6 @@ public class Http2ConnectorFactory extends AbstractSecuredConnectorFactory imple
             http2Connector.setHost( listenAddress );
             server.addConnector(http2Connector);
             server.setDumpAfterStart( Boolean.getBoolean( "dumpAfterStart" ) );
-
-            // ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD
-            ALPN.debug = Boolean.getBoolean( "alpnDebug" );
 
             return http2Connector;
         } catch (IllegalStateException e) {

--- a/src/test/java/winstone/Http2ConnectorFactoryTest.java
+++ b/src/test/java/winstone/Http2ConnectorFactoryTest.java
@@ -1,0 +1,73 @@
+package winstone;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.eclipse.jetty.server.LowResourceMonitor;
+import org.eclipse.jetty.server.ServerConnector;
+import org.junit.Test;
+
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.X509TrustManager;
+
+public class Http2ConnectorFactoryTest extends AbstractWinstoneTest {
+
+    private static final String DISABLE_HOSTNAME_VERIFICATION =
+            "jdk.internal.httpclient.disableHostnameVerification";
+
+    private String request(X509TrustManager tm, int port) throws Exception {
+        String disableHostnameVerification = System.getProperty(DISABLE_HOSTNAME_VERIFICATION);
+        try {
+            System.setProperty(DISABLE_HOSTNAME_VERIFICATION, Boolean.TRUE.toString());
+            HttpRequest request = HttpRequest.newBuilder(new URI("https://localhost:" + port + "/CountRequestsServlet"))
+                    .version(HttpClient.Version.HTTP_2)
+                    .GET()
+                    .build();
+            SSLContext sslContext = SSLContext.getInstance("SSL");
+            sslContext.init(null, new X509TrustManager[] {tm}, null);
+            HttpClient client = HttpClient.newBuilder().sslContext(sslContext).build();
+            HttpResponse<String> response =
+                    client.send(request, HttpResponse.BodyHandlers.ofString());
+            assertEquals(HttpURLConnection.HTTP_OK, response.statusCode());
+            return response.body();
+        } finally {
+            if (disableHostnameVerification != null) {
+                System.setProperty(DISABLE_HOSTNAME_VERIFICATION, disableHostnameVerification);
+            } else {
+                System.clearProperty(DISABLE_HOSTNAME_VERIFICATION);
+            }
+        }
+    }
+
+    @Test
+    public void wildcard() throws Exception {
+        Map<String, String> args = new HashMap<>();
+        args.put("warfile", "target/test-classes/test.war");
+        args.put("prefix", "/");
+        args.put("httpPort", "-1");
+        args.put("http2Port", "0");
+        args.put("http2ListenAddress", "localhost");
+        args.put("httpsKeyStore", "src/ssl/wildcard.jks");
+        args.put("httpsKeyStorePassword", "changeit");
+        winstone = new Launcher(args);
+        int port = ((ServerConnector) winstone.server.getConnectors()[0]).getLocalPort();
+        assertConnectionRefused("127.0.0.2", port);
+        assertEquals(
+                "<html><body>This servlet has been accessed via GET 1001 times</body></html>\r\n",
+                request(new TrustEveryoneManager(), port));
+        LowResourceMonitor lowResourceMonitor = winstone.server.getBean(LowResourceMonitor.class);
+        assertNotNull(lowResourceMonitor);
+        assertFalse(lowResourceMonitor.isLowOnResources());
+        assertTrue(lowResourceMonitor.isAcceptingInLowResources());
+    }
+}


### PR DESCRIPTION
### Problem

Running Winstone in HTTP/2 mode fails with

```
WARNING: Failed to start ALPN
java.lang.IllegalStateException: No Server ALPNProcessors!
        at org.eclipse.jetty.alpn.server.ALPNServerConnectionFactory.<init>(ALPNServerConnectionFactory.java:47)
        at winstone.Http2ConnectorFactory.start(Http2ConnectorFactory.java:79)
        at winstone.Launcher.spawnListener(Launcher.java:269)
        at winstone.Launcher.<init>(Launcher.java:185)
```

I reproduced this error in an integration test.

### Solution

As of https://github.com/eclipse/jetty.project/issues/215 and https://github.com/eclipse/jetty.project/issues/2948 (specifically, eclipse/jetty.project@0303ae4aafe20c6177a834320da90cb89944c01b, eclipse/jetty.project@8b14cbe5f873d7b930ded9872675520d2cf2cf90, eclipse/jetty.project@1fe6c92ee9cce80c180eafb792435b7b6af3d86c, and eclipse/jetty.project@31a9b6f2e84a23f9bdffae2cacff88ab8ea1fc4b), the `alpn-api` dependency is no longer used. In its place is a new `jetty-alpn-java-server` based on Java 11 and later. Including that correct dependency fixes the problem.

### Implementation

Added a new test that now passes with the fix. The changes to the Surefire configuration in `pom.xml` are explained in https://github.com/jenkinsci/winstone/pull/281.

### Testing done

The new test fails without the changes in `src/main` and `pom.xml` and passes with them. I also tested this end-to-end by running Jenkins with these changes and successfully running `curl --http2 127.0.0.1:80` (previously, this was failing).