### PR TITLE
Enable JaCoCo in CI runs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -334,6 +334,12 @@
                   </excludes>
                 </configuration>
               </execution>
+              <execution>
+                <id>report</id>
+                <goals>
+                  <goal>report</goal>
+                </goals>
+              </execution>
             </executions>
           </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -314,4 +314,30 @@
     </dependency>
   </dependencies>
 
+  <profiles>
+    <profile>
+      <id>enable-jacoco</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>prepare-agent</goal>
+                </goals>
+                <configuration>
+                  <excludes>
+                    <exclude>**/Messages.class</exclude>
+                  </excludes>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -322,6 +322,7 @@
           <plugin>
             <groupId>org.jacoco</groupId>
             <artifactId>jacoco-maven-plugin</artifactId>
+            <version>0.8.8</version>
             <executions>
               <execution>
                 <goals>


### PR DESCRIPTION
Creating an `enable-jacoco` Maven profile enables our existing `Jenkinsfile` to provide code coverage information for CI runs.