### PR TITLE
Remove unused JSP options

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@ To run different web applications for diffent virtual hosts:
        --webappsDir             = set directory for multiple webapps to be deployed from
     Other options:
        --javaHome               = Override the JAVA_HOME variable
-       --toolsJar               = The location of tools.jar. Default is JAVA_HOME/lib/tools.jar
        --config                 = load configuration properties from here. Default is ./winstone.properties
        --prefix                 = add this prefix to all URLs (eg http://localhost:8080/prefix/resource). Default is none
        --commonLibFolder        = folder for additional jar files. Default is ./lib
@@ -100,7 +99,6 @@ To run different web applications for diffent virtual hosts:
                                "^.*_anon_.*$" 
        --controlPort            = set the shutdown/control port. -1 to disable, Default disabled
     
-       --useJasper              = enable jasper JSP handling (true/false). Default is false
        --sessionTimeout         = set the http session timeout value in minutes. Default to what webapp specifies, and then to 60 minutes
        --sessionEviction        = set the session eviction timeout for idle sessions in seconds. Default value is 180. -1 never evict, 0 evict on exit
        --mimeTypes=ARG          = define additional MIME type mappings. ARG would be EXT=MIMETYPE:EXT=MIMETYPE:...

--- a/src/main/java/winstone/Launcher.java
+++ b/src/main/java/winstone/Launcher.java
@@ -98,27 +98,6 @@ public class Launcher implements Runnable {
             String defaultJavaHome = System.getProperty("java.home");
             File javaHome = Option.JAVA_HOME.get(args,new File(defaultJavaHome));
             Logger.log(Logger.DEBUG, RESOURCES, "Launcher.UsingJavaHome", javaHome.getPath());
-            File toolsJar = Option.TOOLS_JAR.get(args);
-            if (toolsJar == null) {
-                toolsJar = new File(javaHome, "lib/tools.jar");
-
-                // first try - if it doesn't exist, try up one dir since we might have
-                // the JRE home by mistake
-                if (!toolsJar.exists()) {
-                    File toolsJar2 = new File(javaHome.getParentFile(), "lib/tools.jar");
-                    if (toolsJar2.exists()) {
-                        toolsJar = toolsJar2;
-                    }
-                }
-            }
-
-            // Add tools jar to classloader path
-            if (toolsJar.exists()) {
-                jars.add(toolsJar.toURI().toURL());
-                Logger.log(Logger.DEBUG, RESOURCES, "Launcher.AddedCommonLibJar",
-                        toolsJar.getName());
-            } else if (Option.USE_JASPER.get(args))
-                Logger.log(Logger.WARNING, RESOURCES, "Launcher.ToolsJarNotFound");
 
             // Set up common lib class loader
             File libFolder = Option.COMMON_LIB_FOLDER.get(args,new File("lib"));

--- a/src/main/java/winstone/cmdline/Option.java
+++ b/src/main/java/winstone/cmdline/Option.java
@@ -38,7 +38,6 @@ public class Option<T> {
     public static final OFile WARFILE=file("warfile");
     public static final OFile WEBAPPS_DIR=file("webappsDir");
     public static final OFile JAVA_HOME=file("javaHome");
-    public static final OFile TOOLS_JAR=file("toolsJar");
     public static final OFile CONFIG=file("config");
     public static final OString PREFIX=string("prefix","");
     public static final OFile COMMON_LIB_FOLDER=file("commonLibFolder");
@@ -107,7 +106,6 @@ public class Option<T> {
     public static final OInt JETTY_ACCEPTORS=integer("jettyAcceptorsCount",-1);
     public static final OInt JETTY_SELECTORS=integer("jettySelectorsCount",0);
 
-    public static final OBoolean USE_JASPER=bool("useJasper",false);
     public static final OString MIME_TYPES=string("mimeTypes");
     public static final OInt MAX_PARAM_COUNT=integer("maxParamCount",-1);
     public static final OBoolean USAGE=bool("usage",false);

--- a/src/main/resources/winstone/LocalStrings.properties
+++ b/src/main/resources/winstone/LocalStrings.properties
@@ -49,8 +49,6 @@ Launcher.ListenerStartupError=Error during listener startup
 Launcher.UsingCommonLib=Using common lib folder: [#0]
 Launcher.NoCommonLib=No common lib folder found
 Launcher.UsingJavaHome=Using JAVA_HOME=[#0]
-Launcher.ToolsJarNotFound=WARNING: Tools.jar was not found - jsp compilation will cause errors. \
-Maybe you should set JAVA_HOME using --javaHome
 Launcher.AddedCommonLibJar=Adding [#0] to common classpath
 Launcher.ShutdownRequestReceived=Shutdown request received via the controlPort. Commencing Jetty shutdown
 Launcher.ReloadRequestReceived=Reload request received via the controlPort. Commencing Jetty reload
@@ -77,7 +75,6 @@ Other options:\n\
 
 Launcher.UsageInstructions.Options=\
 \   --javaHome               = Override the JAVA_HOME variable\n\
-\   --toolsJar               = The location of tools.jar. Default is JAVA_HOME/lib/tools.jar\n\
 \   --config                 = load configuration properties from here. Default is ./winstone.properties\n\
 \   --prefix                 = add this prefix to all URLs (eg http://localhost:8080/prefix/resource). Default is none\n\
 \   --commonLibFolder        = folder for additional jar files. Default is ./lib\n\n\
@@ -112,7 +109,6 @@ Launcher.UsageInstructions.Options=\
 \                           "^.*_NULL_.*$", \n\
 \                           "^.*_anon_.*$" \n\
 \   --controlPort            = set the shutdown/control port. -1 to disable, Default disabled\n\n\
-\   --useJasper              = enable jasper JSP handling (true/false). Default is false\n\
 \   --sessionTimeout         = set the http session timeout value in minutes. Default to what webapp specifies, and then to 60 minutes\n\
 \   --sessionEviction        = set the session eviction timeout for idle sessions in seconds. Default value is 180. -1 never evict, 0 evict on exit\n\
 \   --mimeTypes=ARG          = define additional MIME type mappings. ARG would be EXT=MIMETYPE:EXT=MIMETYPE:...\n\


### PR DESCRIPTION
### Problem

Winstone requires Java 11 or newer, where `tools.jar` no longer exists. This implies that the `--toolsJar` is now unusable, but that option still exists.

### Solution

Remove the `tools.jar` option, which no longer has any meaning under Java 11. While here, I also removed the `--useJasper`, which did nothing other than log a warning when `--toolsJar` was not provided and `--useJasper` was true. So removing `--toolsJar` means that the only use of `--useJasper` would be to log a warning if it is provided. So I removed it as well.

For some deeper context, see [the original Winstone docs](http://winstone.sourceforge.net/): `--useJasper` and `--toolsJar` were designed to support a Java 1.4-era use case of running JSP with Jasper. We do not test such a mode or have a use for JSP, and there is no doubt some other way this would need to be implemented in the Java 9+ era. So I deemed it safe to rip this out.

### Testing done

```bash
$ git grep -i jasper
$ git grep -i tools.jar
$ git grep -i toolsjar
```

### Proposed upgrade guide

Remove support for Jasper and JSP servlets. The `--toolsJar` and `--useJasper` options have been removed without replacement.