### PR TITLE
Remove dead references to `executable-war`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # What is Winstone?
 Winstone is a command line interface around Jetty 10.0.x, which implements
 Servlet 4.0 (JakartaEE 8/`javax.servlet.*`), WebSocket/JSR-356, and HTTP/2 support. It is used as the default
-embedded servlet container in Jenkins (via [executable-war](https://github.com/jenkinsci/extras-executable-war) module)
+embedded servlet container in Jenkins (via the `executable` package in the `war` module)
 and can be used by any other web applications that wants to be self-contained.
 
 ## History

--- a/src/main/java/winstone/WinstoneSession.java
+++ b/src/main/java/winstone/WinstoneSession.java
@@ -11,7 +11,7 @@ public class WinstoneSession {
     /**
      * Name of the cookie that stores HTTP session ID.
      */
-    @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "mutated by extras-executable-war")
+    @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "mutated by jenkinsci/jenkins/war/src/main/java/executable/Main.java")
     public static String SESSION_COOKIE_NAME = "JSESSIONID";
 
     private WinstoneSession() {}

--- a/src/main/resources/winstone/LocalStrings.properties
+++ b/src/main/resources/winstone/LocalStrings.properties
@@ -64,7 +64,7 @@ Launcher.CopyingEmbeddedWarfile=Extracting embedded warfile to [#0]
 Launcher.NeedsJDK14=Listener class [#0] needs JDK1.4 support. Disabling
 Launcher.ContainerStartupError=Container startup failed
 
-# Keep synchronized with jenkinsci/extras-executable-war/src/main/java/Main.java
+# Keep synchronized with jenkinsci/jenkins/war/src/main/java/executable/Main.java
 Launcher.UsageInstructions.Header=[#0], (c) 2003-2006 Rick Knowles\n\
 Usage: java winstone.jar [--option=value] [--option=value] [etc]\n\n\
 Required options: either --webroot OR --warfile OR --webappsDir OR --hostsDir\n\


### PR DESCRIPTION
This was inlined to Jenkins core in https://github.com/jenkinsci/jenkins/pull/6706.