### PR TITLE
Deprecate `--extraLibFolder` option

### DIFF
--- a/src/main/java/winstone/Launcher.java
+++ b/src/main/java/winstone/Launcher.java
@@ -120,6 +120,7 @@ public class Launcher implements Runnable {
             File extraLibFolder = Option.EXTRA_LIB_FOLDER.get(args);
             List<URL> extraJars = new ArrayList<>();
             if(extraLibFolder != null && extraLibFolder.exists()){
+                Logger.log(Logger.WARNING, RESOURCES, "Launcher.ExtraLibFolder");
                 File[] children = extraLibFolder.listFiles();
                 if (children != null)
                     for (File aChildren : children)

--- a/src/main/resources/winstone/LocalStrings.properties
+++ b/src/main/resources/winstone/LocalStrings.properties
@@ -63,6 +63,7 @@ Launcher.EmbeddedWebroot=winstoneEmbeddedWAR
 Launcher.CopyingEmbeddedWarfile=Extracting embedded warfile to [#0]
 Launcher.NeedsJDK14=Listener class [#0] needs JDK1.4 support. Disabling
 Launcher.ContainerStartupError=Container startup failed
+Launcher.ExtraLibFolder=You are using an extra library folder, support for which will end on or after January 1, 2023.
 
 # Keep synchronized with jenkinsci/jenkins/war/src/main/java/executable/Main.java
 Launcher.UsageInstructions.Header=[#0], (c) 2003-2006 Rick Knowles\n\


### PR DESCRIPTION
The `--extraLibFolder` option was originally added in #53 for HTTP/2 support. While potential secondary use cases remain, the primary use case no longer exists as of #282. Deprecating this functionality so that it can hopefully be removed in the future to ease the burden of maintaining this component.