### PR TITLE
Remove long-deprecated handler count options

### DIFF
--- a/src/main/java/winstone/Launcher.java
+++ b/src/main/java/winstone/Launcher.java
@@ -86,13 +86,6 @@ public class Launcher implements Runnable {
             this.args = args;
             this.controlPort =Option.CONTROL_PORT.get(args);
 
-            if( Option.HANDLER_COUNT_MAX.get( args, -1 )!=-1){
-                Logger.log(Logger.WARNING, RESOURCES, Option.HANDLER_COUNT_MAX.name);
-            }
-            if( Option.HANDLER_COUNT_MAX_IDLE.get( args, -1 )!=-1){
-                Logger.log(Logger.WARNING, RESOURCES, Option.HANDLER_COUNT_MAX_IDLE.name);
-            }
-
             // Check for java home
             List<URL> jars = new ArrayList<>();
             String defaultJavaHome = System.getProperty("java.home");

--- a/src/main/java/winstone/cmdline/Option.java
+++ b/src/main/java/winstone/cmdline/Option.java
@@ -83,25 +83,6 @@ public class Option<T> {
 
     public static final OBoolean USE_JMX=bool("useJmx",false);
 
-    /**
-     * @deprecated NOT USED
-     * How many requests do we handle concurrently?
-     *
-     * If the system gets really loaded, too many concurrent threads will create vicious cycles
-     * and make everyone slow (or worst case choke every request by OOME), so better to err
-     * on the conservative side (and have inbound connections wait in the queue)
-     */
-    @Deprecated
-    public static final OInt HANDLER_COUNT_MAX     =integer("handlerCountMax",-1);
-
-    /**
-     * @deprecated NOT USED
-     * Leave this number of request handler threads in the pool even when they are idle.
-     * Other threads are destroyed when they are idle to free up resources.
-     */
-    @Deprecated
-    public static final OInt HANDLER_COUNT_MAX_IDLE=integer("handlerCountMaxIdle",-1);
-
     public static final OInt QTP_MAXTHREADS=integer("qtpMaxThreadsCount",-1);
     public static final OInt JETTY_ACCEPTORS=integer("jettyAcceptorsCount",-1);
     public static final OInt JETTY_SELECTORS=integer("jettySelectorsCount",0);

--- a/src/main/resources/winstone/LocalStrings.properties
+++ b/src/main/resources/winstone/LocalStrings.properties
@@ -162,6 +162,3 @@ Ajp13ConnectorFactory.NotSupported=\
   For reverse proxying, please use HTTP instead of AJP.
 
 Http2ConnectorFactory.FailedStart.ALPN=Failed to start ALPN
-
-handlerCountMax=Parameter handlerCountMax is now deprecated
-handlerCountMaxIdle=Parameter handlerCountMaxIdle is now deprecated


### PR DESCRIPTION
These options have been deprecated since 2018 in #54 and have long been no-ops.