### PR TITLE
Fix some Maven Shade Plugin warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,10 +106,25 @@
         <configuration>
           <filters>
             <filter>
-              <artifact>org.eclipse.jetty.orbit:javax.servlet</artifact>
+              <artifact>io.jenkins.lib:support-log-formatter</artifact>
               <excludes>
-                <exclude>META-INF/eclipse.inf</exclude>
-                <exclude>META-INF/ECLIPSEF.*</exclude>
+                <exclude>META-INF/MANIFEST.MF</exclude>
+              </excludes>
+            </filter>
+            <filter>
+              <artifact>org.eclipse.jetty*</artifact>
+              <excludes>
+                <exclude>META-INF/MANIFEST.MF</exclude>
+                <exclude>module-info.class</exclude>
+                <exclude>module-info.java</exclude>
+              </excludes>
+            </filter>
+            <filter>
+              <artifact>org.slf4j</artifact>
+              <excludes>
+                <exclude>META-INF/MANIFEST.MF</exclude>
+                <exclude>META-INF/versions/9/module-info.class</exclude>
+                <exclude>META-INF/versions/9/module-info.java</exclude>
               </excludes>
             </filter>
           </filters>


### PR DESCRIPTION
Fixes the following Maven Shade Plugin warnings

```
[INFO] No artifact matching filter org.eclipse.jetty.orbit:javax.servlet
[WARNING] Discovered module-info.class. Shading will break its strong encapsulation.
[WARNING] slf4j-api-2.0.6.jar, slf4j-jdk14-2.0.6.jar define 1 overlapping classes: 
[WARNING]   - META-INF.versions.9.module-info
[WARNING] http2-common-10.0.13.jar, http2-hpack-10.0.13.jar, http2-server-10.0.13.jar, jetty-alpn-java-server-10.0.13.jar, jetty-alpn-server-10.0.13.jar, jetty-http-10.0.13.jar, jetty-io-10.0.13.jar, jetty-jmx-10.0.13.jar, jetty-security-10.0.13.jar, jetty-server-10.0.13.jar, jetty-servlet-10.0.13.jar, jetty-servlet-api-4.0.6.jar, jetty-util-10.0.13.jar, jetty-webapp-10.0.13.jar, jetty-xml-10.0.13.jar, slf4j-api-2.0.6.jar, slf4j-jdk14-2.0.6.jar, support-log-formatter-1.2.jar, websocket-core-common-10.0.13.jar, websocket-core-server-10.0.13.jar, websocket-jetty-api-10.0.13.jar, websocket-jetty-common-10.0.13.jar, websocket-jetty-server-10.0.13.jar, websocket-servlet-10.0.13.jar, winstone-6.9-SNAPSHOT.jar define 1 overlapping resource: 
[WARNING]   - META-INF/MANIFEST.MF
[WARNING] http2-common-10.0.13-sources.jar, http2-hpack-10.0.13-sources.jar, http2-server-10.0.13-sources.jar, jetty-alpn-java-server-10.0.13-sources.jar, jetty-alpn-server-10.0.13-sources.jar, jetty-http-10.0.13-sources.jar, jetty-io-10.0.13-sources.jar, jetty-jmx-10.0.13-sources.jar, jetty-security-10.0.13-sources.jar, jetty-server-10.0.13-sources.jar, jetty-servlet-10.0.13-sources.jar, jetty-servlet-api-4.0.6-sources.jar, jetty-util-10.0.13-sources.jar, jetty-webapp-10.0.13-sources.jar, jetty-xml-10.0.13-sources.jar, slf4j-api-2.0.6-sources.jar, slf4j-jdk14-2.0.6-sources.jar, support-log-formatter-1.2-sources.jar, websocket-core-common-10.0.13-sources.jar, websocket-core-server-10.0.13-sources.jar, websocket-jetty-api-10.0.13-sources.jar, websocket-jetty-common-10.0.13-sources.jar, websocket-jetty-server-10.0.13-sources.jar, websocket-servlet-10.0.13-sources.jar define 1 overlapping resource: 
[WARNING]   - META-INF/MANIFEST.MF
[WARNING] http2-common-10.0.13-sources.jar, http2-hpack-10.0.13-sources.jar, http2-server-10.0.13-sources.jar, jetty-alpn-java-server-10.0.13-sources.jar, jetty-alpn-server-10.0.13-sources.jar, jetty-http-10.0.13-sources.jar, jetty-io-10.0.13-sources.jar, jetty-jmx-10.0.13-sources.jar, jetty-security-10.0.13-sources.jar, jetty-server-10.0.13-sources.jar, jetty-servlet-10.0.13-sources.jar, jetty-util-10.0.13-sources.jar, jetty-webapp-10.0.13-sources.jar, jetty-xml-10.0.13-sources.jar, websocket-core-common-10.0.13-sources.jar, websocket-core-server-10.0.13-sources.jar, websocket-jetty-api-10.0.13-sources.jar, websocket-jetty-common-10.0.13-sources.jar, websocket-jetty-server-10.0.13-sources.jar, websocket-servlet-10.0.13-sources.jar define 1 overlapping resource: 
[WARNING]   - module-info.java
```

by simply excluding the duplicate resources. Not really sure what the warnings about "breaking strong encapsulation" were about, but we're not using JPMS anyway so it shouldn't matter. With this PR the following warnings remain:

```
[WARNING] http2-common-10.0.13.jar, http2-hpack-10.0.13.jar, http2-server-10.0.13.jar, jetty-alpn-java-server-10.0.13.jar, jetty-alpn-server-10.0.13.jar, jetty-http-10.0.13.jar, jetty-io-10.0.13.jar, jetty-jmx-10.0.13.jar, jetty-security-10.0.13.jar, jetty-server-10.0.13.jar, jetty-servlet-10.0.13.jar, jetty-util-10.0.13.jar, jetty-webapp-10.0.13.jar, jetty-xml-10.0.13.jar, websocket-core-common-10.0.13.jar, websocket-core-server-10.0.13.jar, websocket-jetty-api-10.0.13.jar, websocket-jetty-common-10.0.13.jar, websocket-jetty-server-10.0.13.jar, websocket-servlet-10.0.13.jar define 2 overlapping resources: 
[WARNING]   - META-INF/LICENSE
[WARNING]   - META-INF/NOTICE.txt
[WARNING] http2-common-10.0.13-sources.jar, http2-hpack-10.0.13-sources.jar, http2-server-10.0.13-sources.jar, jetty-alpn-java-server-10.0.13-sources.jar, jetty-alpn-server-10.0.13-sources.jar, jetty-http-10.0.13-sources.jar, jetty-io-10.0.13-sources.jar, jetty-jmx-10.0.13-sources.jar, jetty-security-10.0.13-sources.jar, jetty-server-10.0.13-sources.jar, jetty-servlet-10.0.13-sources.jar, jetty-servlet-api-4.0.6-sources.jar, jetty-util-10.0.13-sources.jar, jetty-webapp-10.0.13-sources.jar, jetty-xml-10.0.13-sources.jar, websocket-core-common-10.0.13-sources.jar, websocket-core-server-10.0.13-sources.jar, websocket-jetty-api-10.0.13-sources.jar, websocket-jetty-common-10.0.13-sources.jar, websocket-jetty-server-10.0.13-sources.jar, websocket-servlet-10.0.13-sources.jar define 2 overlapping resources: 
[WARNING]   - META-INF/LICENSE
[WARNING]   - META-INF/NOTICE.txt
```

but since legal stuff gets complicated very quickly I am not touching them for now. To test this I verified that the shaded JAR had the same files (modulo the removal of SLF4J's `./META-INF/versions/9/module-info.class` as expected) and that `META-INF/MANIFEST.MF` was the same before and after this PR.