### PR TITLE
feat: add excludeProtocols command-line option

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ To run different web applications for diffent virtual hosts:
        --httpsSniHostCheck      = if the SNI Host name must match when there is an SNI certificate. Check disabled per default
        --httpsSniRequired       = if a SNI certificate is required. Disabled per default
        --http2ListenAddress     = set the http2 listening address. Default is all interfaces
+       --excludeProtocols       = set protocol versions to exclude. (comma separated list, use blank quote " " to exclude none)
+                                  (default is "SSL", "SSLv2", "SSLv2Hello", "SSLv3")
        --excludeCipherSuites    = set the ciphers to exclude (comma separated, use blank quote " " to exclude none) (default is 
                                // Exclude weak / insecure ciphers 
                                "^.*_(MD5|SHA|SHA1)$", 

--- a/src/main/java/winstone/AbstractSecuredConnectorFactory.java
+++ b/src/main/java/winstone/AbstractSecuredConnectorFactory.java
@@ -104,9 +104,6 @@ public abstract class AbstractSecuredConnectorFactory implements ConnectorFactor
             if(excludeProtos!=null&&excludeProtos.length()>0) {
                 String[] protos = excludeProtos.split(",");
                 ssl.setExcludeProtocols(protos);
-            } else {
-                String[] default_excluded_protocols = {"SSL", "SSLv2", "SSLv2Hello", "SSLv3"};
-                ssl.setExcludeProtocols(default_excluded_protocols);
             }
             String excludeCiphers = Option.HTTPS_EXCLUDE_CIPHER_SUITES.get(args);
             if(excludeCiphers!=null&&excludeCiphers.length()>0) {

--- a/src/main/java/winstone/AbstractSecuredConnectorFactory.java
+++ b/src/main/java/winstone/AbstractSecuredConnectorFactory.java
@@ -100,12 +100,19 @@ public abstract class AbstractSecuredConnectorFactory implements ConnectorFactor
             ssl.setKeyManagerPassword(privateKeyPassword);
             ssl.setKeyManagerFactoryAlgorithm(Option.HTTPS_KEY_MANAGER_TYPE.get(args));
             ssl.setCertAlias(Option.HTTPS_CERTIFICATE_ALIAS.get(args));
-            ssl.setExcludeProtocols("SSLv3", "SSLv2", "SSLv2Hello");
+            String excludeProtos = Option.HTTPS_EXCLUDE_PROTOCOLS.get(args);
+            if(excludeProtos!=null&&excludeProtos.length()>0) {
+                String[] protos = excludeProtos.split(",");
+                ssl.setExcludeProtocols(protos);
+            }
             String excludeCiphers = Option.HTTPS_EXCLUDE_CIPHER_SUITES.get(args);
             if(excludeCiphers!=null&&excludeCiphers.length()>0) {
                 String[] cipherSuites = excludeCiphers.split(",");
                 ssl.setExcludeCipherSuites(cipherSuites);
             }
+            Logger.log(Level.INFO, SSL_RESOURCES, //
+                        "HttpsListener.ExcludeProtocols", //
+                        Arrays.asList(ssl.getExcludeProtocols()));
             Logger.log(Level.INFO, SSL_RESOURCES, //
                         "HttpsListener.ExcludeCiphers", //
                         Arrays.asList(ssl.getExcludeCipherSuites()));

--- a/src/main/java/winstone/AbstractSecuredConnectorFactory.java
+++ b/src/main/java/winstone/AbstractSecuredConnectorFactory.java
@@ -104,6 +104,9 @@ public abstract class AbstractSecuredConnectorFactory implements ConnectorFactor
             if(excludeProtos!=null&&excludeProtos.length()>0) {
                 String[] protos = excludeProtos.split(",");
                 ssl.setExcludeProtocols(protos);
+            } else {
+                String[] default_excluded_protocols = {"SSL", "SSLv2", "SSLv2Hello", "SSLv3"};
+                ssl.setExcludeProtocols(default_excluded_protocols);
             }
             String excludeCiphers = Option.HTTPS_EXCLUDE_CIPHER_SUITES.get(args);
             if(excludeCiphers!=null&&excludeCiphers.length()>0) {

--- a/src/main/java/winstone/cmdline/Option.java
+++ b/src/main/java/winstone/cmdline/Option.java
@@ -70,6 +70,7 @@ public class Option<T> {
     public static final OString HTTPS_KEY_MANAGER_TYPE=string("httpsKeyManagerType","SunX509");
     public static final OBoolean HTTPS_VERIFY_CLIENT=bool("httpsVerifyClient",false);
     public static final OString HTTPS_CERTIFICATE_ALIAS=string("httpsCertificateAlias");
+    public static final OString HTTPS_EXCLUDE_PROTOCOLS=string("excludeProtocols");
     public static final OString HTTPS_EXCLUDE_CIPHER_SUITES=string("excludeCipherSuites");
     public static final OBoolean HTTPS_REDIRECT_HTTP=bool("httpsRedirectHttp", false);
     public static final OBoolean HTTPS_SNI_HOST_CHECK=bool("httpsSniHostCheck", false);

--- a/src/main/java/winstone/cmdline/Option.java
+++ b/src/main/java/winstone/cmdline/Option.java
@@ -70,7 +70,7 @@ public class Option<T> {
     public static final OString HTTPS_KEY_MANAGER_TYPE=string("httpsKeyManagerType","SunX509");
     public static final OBoolean HTTPS_VERIFY_CLIENT=bool("httpsVerifyClient",false);
     public static final OString HTTPS_CERTIFICATE_ALIAS=string("httpsCertificateAlias");
-    public static final OString HTTPS_EXCLUDE_PROTOCOLS=string("excludeProtocols");
+    public static final OString HTTPS_EXCLUDE_PROTOCOLS=string("excludeProtocols", "SSL, SSLv2, SSLv2Hello, SSLv3");
     public static final OString HTTPS_EXCLUDE_CIPHER_SUITES=string("excludeCipherSuites");
     public static final OBoolean HTTPS_REDIRECT_HTTP=bool("httpsRedirectHttp", false);
     public static final OBoolean HTTPS_SNI_HOST_CHECK=bool("httpsSniHostCheck", false);

--- a/src/main/resources/winstone/LocalStrings.properties
+++ b/src/main/resources/winstone/LocalStrings.properties
@@ -135,6 +135,7 @@ HttpsListener.ErrorGettingContext=Error getting the SSL context object
 HttpsListener.KeyCount=Keys/certificates found: [#0]
 HttpsListener.KeyFound=Key: [#0] - [#1]
 HttpsListener.KeyStoreNotFound=No SSL key store found at [#0]
+HttpsListener.ExcludeProtocols=Exclude Protocols [#0]
 HttpsListener.ExcludeCiphers=Exclude Ciphers [#0]
 
 Http2ConnectorFactory.FailedStart.ALPN=Failed to start ALPN

--- a/src/main/resources/winstone/LocalStrings.properties
+++ b/src/main/resources/winstone/LocalStrings.properties
@@ -77,6 +77,8 @@ Launcher.UsageInstructions.Options=\
 \   --httpsSniHostCheck      = if the SNI Host name must match when there is an SNI certificate. Check disabled per default\n\
 \   --httpsSniRequired       = if a SNI certificate is required. Disabled per default\n\
 \   --http2ListenAddress     = set the http2 listening address. Default is all interfaces\n\
+\   --excludeProtocols       = set protocol versions to exclude. (comma separated list, use blank quote " " to exclude none)\n\
+\                              (default is "SSL", "SSLv2", "SSLv2Hello", "SSLv3")\n\
 \   --excludeCipherSuites    = set the ciphers to exclude (comma separated, use blank quote " " to exclude none) (default is\n\
 \                           // Exclude weak / insecure ciphers \n\
 \                           "^.*_(MD5|SHA|SHA1)$", \n\


### PR DESCRIPTION
This PR adds a command-line option for users to specify excluded protocols.

Jetty already has a [default exclusion list](https://github.com/eclipse/jetty.project/blob/jetty-9.4.x/jetty-util/src/main/java/org/eclipse/jetty/util/ssl/SslContextFactory.java#L121)
Those values are added to the README

Closes #308 


- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
