### PR TITLE
Tolerate `IllegalStateException` from `Runtime.addShutdownHook`

### DIFF
--- a/src/main/java/winstone/Launcher.java
+++ b/src/main/java/winstone/Launcher.java
@@ -220,7 +220,11 @@ public class Launcher implements Runnable {
                 shutdown();
         }
 
-        Runtime.getRuntime().addShutdownHook(new ShutdownHook(this));
+        try {
+            Runtime.getRuntime().addShutdownHook(new ShutdownHook(this));
+        } catch (IllegalStateException x) {
+            Logger.logDirectMessage(Level.FINE, null, "Could not add logger shutdown hook", x);
+        }
     }
 
     private synchronized boolean isShutdownComplete() {


### PR DESCRIPTION
Amends #310. I observed a Jenkins log including

```
2023-01-27 19:48:23.847+0000 [id=1]	INFO	org.eclipse.jetty.server.Server#doStart: Started Server@…{STARTING}[…,sto=0] @11198ms
java.lang.IllegalStateException: Shutdown in progress
	at java.base/java.lang.ApplicationShutdownHooks.add(ApplicationShutdownHooks.java:66)
	at java.base/java.lang.Runtime.addShutdownHook(Runtime.java:216)
	at winstone.Launcher.<init>(Launcher.java:223)
	at winstone.Launcher.main(Launcher.java:492)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at executable.Main.main(Main.java:347)
2023-01-27 19:48:23.853+0000 [id=1]	SEVERE	winstone.Logger#logInternal: Container startup failed
java.lang.IllegalStateException: Shutdown in progress
	at java.base/java.lang.ApplicationShutdownHooks.add(ApplicationShutdownHooks.java:66)
	at java.base/java.lang.Runtime.addShutdownHook(Runtime.java:216)
	at winstone.Launcher.<init>(Launcher.java:223)
	at winstone.Launcher.main(Launcher.java:492)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at executable.Main.main(Main.java:347)
2023-01-27 19:48:23.939+0000 [id=27]	INFO	winstone.Logger#logInternal: Winstone Servlet Engine running: controlPort=disabled
```

Probably something else had failed earlier, or would fail, but at any rate this stack trace is a distraction—adding the shutdown hook for logging is a best effort.
