### PR TITLE
Add WebAssembly MIME type

### DIFF
--- a/src/main/resources/winstone/mime.properties
+++ b/src/main/resources/winstone/mime.properties
@@ -859,6 +859,7 @@ vxml=application/voicexml+xml
 w3d=application/x-director
 wad=application/x-doom
 war=application/octet-stream
+wasm=application/wasm
 wav=audio/x-wav
 wax=audio/x-ms-wax
 wbmp=image/vnd.wap.wbmp


### PR DESCRIPTION
Consistent with the default configuration of upstream Jetty and Nginx. (Apache httpd does not define a default MIME type for `.wasm` extensions, but presumably this is just a missing feature and they would accept a similar patch if offered one.)