### PR TITLE
Add AV1 Image File Format (AVIF) MIME type

### DIFF
--- a/src/main/resources/winstone/mime.properties
+++ b/src/main/resources/winstone/mime.properties
@@ -44,6 +44,7 @@ atomcat=application/atomcat+xml
 atomsvc=application/atomsvc+xml
 atx=application/vnd.antix.game-component
 au=audio/basic
+avif=image/avif
 avi=video/x-msvideo
 avx=video/x-rad-screenplay
 aw=application/applixware


### PR DESCRIPTION
This is a newer image format developed in 2019 by Netflix. The MIME type used here matches upstream Jetty and Nginx (Apache httpd does not have one, but this is presumably a missing feature for which they would accept a patch like this one.)