### PR TITLE
Add support for Unix Domain Sockets.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ To run different web applications for diffent virtual hosts:
     
        --httpPort               = set the http listening port. -1 to disable, Default is 8080
        --httpListenAddress      = set the http listening address. Default is all interfaces
+       --httpUnixDomainPath     = set the http unix domain path. Default is no path
        --httpKeepAliveTimeout   = how long idle HTTP keep-alive connections are kept around (in ms; default 30000)?
        --httpsPort              = set the https listening port. -1 to disable, Default is disabled
        --httpsListenAddress     = set the https listening address. Default is all interfaces

--- a/pom.xml
+++ b/pom.xml
@@ -279,6 +279,10 @@
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-unixdomain-server</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-util</artifactId>
     </dependency>
     <dependency>
@@ -328,6 +332,11 @@
     <dependency>
       <groupId>org.junit.vintage</groupId>
       <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-client</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/winstone/HttpConnectorFactory.java
+++ b/src/main/java/winstone/HttpConnectorFactory.java
@@ -27,8 +27,9 @@ public class HttpConnectorFactory implements ConnectorFactory {
     public Connector start( Map<String, String> args, Server server) throws IOException {
         // Load resources
         int listenPort = Option.HTTP_PORT.get(args);
+        String listenUnixDomainPath = Option.HTTP_UNIX_DOMAIN_PATH.get(args);
 
-        if (listenPort < 0) {
+        if (listenPort < 0 && listenUnixDomainPath == null) {
             return null;
         }
         else {
@@ -36,6 +37,7 @@ public class HttpConnectorFactory implements ConnectorFactory {
                 .withServer(server)
                 .withAcceptors(Option.JETTY_ACCEPTORS.get(args))
                 .withSelectors(Option.JETTY_SELECTORS.get(args))
+                .withListenerUnixDomainPath(listenUnixDomainPath)
                 .withListenerPort(listenPort)
                 .withSecureListenerPort(Option.HTTPS_PORT.get(args, -1))
                 .withListenerAddress(Option.HTTP_LISTEN_ADDRESS.get(args))

--- a/src/main/java/winstone/HttpsConnectorFactory.java
+++ b/src/main/java/winstone/HttpsConnectorFactory.java
@@ -12,7 +12,6 @@ import java.util.Map;
 import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.handler.HandlerList;
 import org.eclipse.jetty.server.handler.SecuredRedirectHandler;
 
@@ -67,8 +66,8 @@ public class HttpsConnectorFactory extends AbstractSecuredConnectorFactory imple
             .withSniHostCheck(Option.HTTPS_SNI_HOST_CHECK.get(args))
             .withSniRequired(Option.HTTPS_SNI_REQUIRED.get(args))
             .withSslContext(getSSLContext(args));
-        ServerConnector sc = scb.build();
-        server.addConnector(sc);
-        return sc;
+        Connector c = scb.build();
+        server.addConnector(c);
+        return c;
     }
 }

--- a/src/main/java/winstone/cmdline/Option.java
+++ b/src/main/java/winstone/cmdline/Option.java
@@ -51,14 +51,15 @@ public class Option<T> {
     // these are combined with protocol to form options
     private static final OInt _PORT = integer("Port");
     private static final OString _LISTEN_ADDRESS = string("ListenAddress");
+    private static final OString _UNIX_DOMAIN_PATH=string("UnixDomainPath");
     /**
      * Number of milliseconds for the HTTP keep-alive to hang around until the next request is sent.
      */
     private static final OInt _KEEP_ALIVE_TIMEOUT = integer("KeepAliveTimeout",30000);
 
-
     public static final OInt HTTP_PORT=integer("http"+_PORT,8080);
     public static final OString HTTP_LISTEN_ADDRESS=string("http"+ _LISTEN_ADDRESS);
+    public static final OString HTTP_UNIX_DOMAIN_PATH=string("http"+ _UNIX_DOMAIN_PATH);
     public static final OInt HTTP_KEEP_ALIVE_TIMEOUT=integer("http" + _KEEP_ALIVE_TIMEOUT, _KEEP_ALIVE_TIMEOUT.defaultValue);
 
     public static final OInt HTTPS_PORT=integer("https"+_PORT,-1);

--- a/src/main/resources/winstone/LocalStrings.properties
+++ b/src/main/resources/winstone/LocalStrings.properties
@@ -65,6 +65,7 @@ Launcher.UsageInstructions.Options=\
 \   --debug                  = set the level of Winstone debug msgs (1-9). Default is 5 (INFO level)\n\n\
 \   --httpPort               = set the http listening port. -1 to disable, Default is 8080\n\
 \   --httpListenAddress      = set the http listening address. Default is all interfaces\n\
+\   --httpUnixDomainPath     = set the http unix domain path. Default is no path\n\
 \   --httpKeepAliveTimeout   = how long idle HTTP keep-alive connections are kept around (in ms; default 30000)?\n\
 \   --httpsPort              = set the https listening port. -1 to disable, Default is disabled\n\
 \   --httpsListenAddress     = set the https listening address. Default is all interfaces\n\

--- a/src/test/java/winstone/HttpConnectorFactoryTest.java
+++ b/src/test/java/winstone/HttpConnectorFactoryTest.java
@@ -1,5 +1,6 @@
 package winstone;
 
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -38,7 +39,18 @@ public class HttpConnectorFactoryTest extends AbstractWinstoneTest {
         args.put("warfile", "target/test-classes/test.war");
         args.put("prefix", "/");
         args.put("httpUnixDomainPath", "target/jetty.socket");
-        winstone = new Launcher(args);
+        
+        try {
+            winstone = new Launcher(args);
+        }
+        catch (IOException ioe) {
+            if (ioe.getCause() instanceof UnsupportedOperationException) {
+                /* skip JDKs less than 16 */
+                return;
+            }
+            throw ioe;
+        }
+
         String path = ((UnixDomainServerConnector)winstone.server.getConnectors()[0]).getUnixDomainPath().toString();
 
         assertEquals(


### PR DESCRIPTION
Added --httpUnixDomainPath option to specify a unix domain socket to bind to instead of a port.

Use jetty-client for HTTP client tests, so that it is possible to test unix domain socket support. While JEP 380 added unix domain socket support to the JDK, java.net.http.HttpClient was overlooked.

Fixes https://github.com/jenkinsci/winstone/issues/345

### Testing done

Unit tests updated to support connection via both TCP ports and unix domain sockets.

```[tasklist]
### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

