### PR TITLE
Clean up POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -187,16 +187,6 @@
       <id>repo.jenkins-ci.org</id>
       <url>https://repo.jenkins-ci.org/public/</url>
     </repository>
-    <repository>
-      <id>jetty.snapshots</id>
-      <url>https://oss.sonatype.org/content/repositories/jetty-snapshots</url>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
   </repositories>
 
   <pluginRepositories>
@@ -221,10 +211,6 @@
         <version>${jetty.version}</version>
         <type>pom</type>
         <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.hamcrest</groupId>
-        <artifactId>hamcrest</artifactId>
       </dependency>
       <!-- TODO SLF4J-437 use BOM -->
       <dependency>


### PR DESCRIPTION
- Remove unnecessary `<dependencyManagement>` entry (duplicated in parent POM)
- Remove unused repository

Tested with `mvn clean verify`.