### PR TITLE
Remove support for multiple WAR files

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,6 @@ To run a single war file:
 
     java -jar winstone.jar --warfile=<location of warfile> (+ other options)
 
-To run a directory full of war files:
-
-    java -jar winstone.jar --webappsDir=<location of webapps directory> (+ other options)
-
 To run locally exploded web archive:
 
     java -jar winstone.jar --webroot=<location of webroot> (+ other options)
@@ -51,10 +47,9 @@ To run locally exploded web archive:
     Winstone Servlet Engine, (c) 2003-2006 Rick Knowles
     Usage: java winstone.jar [--option=value] [--option=value] [etc]
     
-    Required options: either --webroot OR --warfile OR --webappsDir
+    Required options: either --webroot OR --warfile
        --webroot                = set document root folder.
        --warfile                = set location of warfile to extract from.
-       --webappsDir             = set directory for multiple webapps to be deployed from
     Other options:
        --javaHome               = Override the JAVA_HOME variable
        --config                 = load configuration properties from here. Default is ./winstone.properties
@@ -145,20 +140,6 @@ just supply the warfile or webroot directory as an argument:
 * `java -jar winstone.jar <webroot or warfile>`, (this method auto-detects the type) or
 * `java -jar winstone.jar --webroot=<webroot>`, or
 * `java -jar winstone.jar --warfile=<warfile>`
-
-If you need to support *multiple webapps*, use the `--webappsDir` switch,
-to which you pass a directory that contains multiple warfiles/webroots.
-
-* `java -jar winstone.jar --webappsDir=<dir containing multiple webroots>`
-
-The directory becomes the prefix name for that webapp (so hello becomes `/hello`, etc).
-The directory named ROOT becomes the no-prefix webapp.
-
-So, for example, if you had a directory `/usr/local/webapps` which contained
-sub-directories `ROOT` and `test`, if you executed
-`java -jar winstone.jar --webappsDir=/usr/local/webapps`, you would find that
-the test folder would act as a webroot for requests prefixed with
-`/test`, while other requests would go to the webapp in the `ROOT` folder
 
 ## Development
 If you have some unit test failures you may add an interface/ip alias such

--- a/src/main/java/winstone/HostGroup.java
+++ b/src/main/java/winstone/HostGroup.java
@@ -7,9 +7,7 @@
 package winstone;
 
 import org.eclipse.jetty.server.Server;
-import winstone.cmdline.Option;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.Hashtable;
 import java.util.Map;
@@ -38,12 +36,8 @@ public class HostGroup {
         this.server = server;
         this.hostConfigs = new Hashtable<>();
 
-        // Is this the single or multiple configuration ? Check args
-        File webappsDir = Option.WEBAPPS_DIR.get(args);
-
         // If host mode
-        initHost(webappsDir, DEFAULT_HOSTNAME, commonLibCL,
-                args);
+        initHost(DEFAULT_HOSTNAME, commonLibCL, args);
         this.defaultHostName = DEFAULT_HOSTNAME;
         Logger.log(Level.FINER, Launcher.RESOURCES, "HostGroup.InitSingleComplete",
                 this.hostConfigs.size() + "", this.hostConfigs.keySet() + "");
@@ -59,12 +53,9 @@ public class HostGroup {
         return this.hostConfigs.get(this.defaultHostName);
     }
 
-    protected void initHost(File webappsDir, String hostname,
-                            ClassLoader commonLibCL,
-                            Map<String, String> args) throws IOException {
+    protected void initHost(String hostname, ClassLoader commonLibCL, Map<String, String> args) throws IOException {
         Logger.log(Level.FINER, Launcher.RESOURCES, "HostGroup.DeployingHost", hostname);
-        HostConfiguration config = new HostConfiguration(server, hostname, commonLibCL,
-                args, webappsDir);
+        HostConfiguration config = new HostConfiguration(server, hostname, commonLibCL, args);
         this.hostConfigs.put(hostname, config);
     }
 }

--- a/src/main/java/winstone/Launcher.java
+++ b/src/main/java/winstone/Launcher.java
@@ -484,8 +484,7 @@ public class Launcher implements Runnable {
         deployEmbeddedWarfile(args);
 
         // Check for embedded warfile
-        if (!Option.WEBROOT.isIn(args) && !Option.WARFILE.isIn(args)
-         && !Option.WEBAPPS_DIR.isIn(args)) {
+        if (!Option.WEBROOT.isIn(args) && !Option.WARFILE.isIn(args)) {
             printUsage();
             return;
         }
@@ -561,7 +560,6 @@ public class Launcher implements Runnable {
 
             Option.WARFILE.put(args, tempWarfile.getAbsolutePath());
             Option.WARFILE.put(args, tempWebroot.getAbsolutePath());
-            Option.WEBAPPS_DIR.remove(args);
         }
     }
 

--- a/src/main/java/winstone/cmdline/Option.java
+++ b/src/main/java/winstone/cmdline/Option.java
@@ -37,7 +37,6 @@ public class Option<T> {
     
     public static final OFile WEBROOT=file("webroot");
     public static final OFile WARFILE=file("warfile");
-    public static final OFile WEBAPPS_DIR=file("webappsDir");
     public static final OFile JAVA_HOME=file("javaHome");
     public static final OFile CONFIG=file("config");
     public static final OString PREFIX=string("prefix","");

--- a/src/main/resources/winstone/LocalStrings.properties
+++ b/src/main/resources/winstone/LocalStrings.properties
@@ -5,12 +5,10 @@ WebAppConfig.LoggerDisabled=Access logging disabled - no logger class defined
 
 HostConfig.PrefixUnknown=Unknown webapp prefix: [#0]
 HostConfig.InitComplete=Initialized [#0] webapps: prefixes - [#1]
-HostConfig.DeployingWebapp=Deployed web application found at [#0]
 HostConfig.WarFileInvalid=The warfile supplied is unavailable or invalid ([#0])
 HostConfig.WebRootNotDirectory=The webroot supplied is not a valid directory ([#0])
 HostConfig.WebRootExists=The webroot supplied already exists - overwriting where newer ([#0])
 HostConfig.BeginningWarExtraction=Beginning extraction from war file
-HostConfig.WebappInitError=Error initializing web application: prefix [[#0]]
 
 HostGroup.InitSingleComplete=Initialized in non-virtual-host mode
 HostGroup.DeployingHost=Deploying host found at [#0]

--- a/src/main/resources/winstone/LocalStrings.properties
+++ b/src/main/resources/winstone/LocalStrings.properties
@@ -4,10 +4,7 @@ WebAppConfig.LoggerError=Error instantiating access logger class: [#0]
 WebAppConfig.LoggerDisabled=Access logging disabled - no logger class defined
 
 HostConfig.PrefixUnknown=Unknown webapp prefix: [#0]
-HostConfig.WebAppDirNotFound=Webapps dir [#0] not found
-HostConfig.WebAppDirIsNotDirectory=Webapps dir [#0] is not a directory
 HostConfig.InitComplete=Initialized [#0] webapps: prefixes - [#1]
-HostConfig.SkippingWarfileDir=Webapp dir deployment [#0] skipped, since there is a war file of the same name to check for re-extraction
 HostConfig.DeployingWebapp=Deployed web application found at [#0]
 HostConfig.WarFileInvalid=The warfile supplied is unavailable or invalid ([#0])
 HostConfig.WebRootNotDirectory=The webroot supplied is not a valid directory ([#0])
@@ -47,10 +44,9 @@ Launcher.ExtraLibFolder=You are using an extra library folder, support for which
 # Keep synchronized with jenkinsci/jenkins/war/src/main/java/executable/Main.java
 Launcher.UsageInstructions.Header=[#0], (c) 2003-2006 Rick Knowles\n\
 Usage: java winstone.jar [--option=value] [--option=value] [etc]\n\n\
-Required options: either --webroot OR --warfile OR --webappsDir \n\
+Required options: either --webroot OR --warfile \n\
 \   --webroot                = set document root folder.\n\
 \   --warfile                = set location of warfile to extract from.\n\
-\   --webappsDir             = set directory for multiple webapps to be deployed from\n\
 Other options:\n\
 
 Launcher.UsageInstructions.Options=\


### PR DESCRIPTION
Winstone contains 100 or so lines of code for a `--webappsDir` switch to run a directory full of WAR files, each with their own request logger which logs requests to a different file. There are no references to this in the `jenkinsci`, `jenkins-infra`, and `cloudbees` GitHub organizations. There is no test coverage for the feature. The single reference in Jira is [JENKINS-5307](https://issues.jenkins.io/browse/JENKINS-5307), from 2010. While I am aware of people running Jenkins as a WAR file in Tomcat alongside other WAR files, I am not aware of anyone using Winstone to run multiple WAR files. I think it is quite likely there are zero people using this feature.

This all is changing in Jetty 12, which now does request logging at a per-`Server` level, not a per-webapp level. Thus the current code would require significant changes to support the existing functionality. Since it has no test coverage, and since we think there are zero people using it, this PR removes the feature. That way, we won't have to port it to Jetty 12, and we also won't have to manually test the result.

### Proposed changelog and upgrade guide entries

The `--webappsDir` argument to run Winstone with a directory full of WAR files has been removed without replacement.

### Testing done

`mvn clean verify`