### PR TITLE
Set server on `WebApplicationContext`

### DIFF
--- a/src/main/java/winstone/HostConfiguration.java
+++ b/src/main/java/winstone/HostConfiguration.java
@@ -182,6 +182,7 @@ public class HostConfiguration {
                 getSessionHandler().getSessionCache().setEvictionPolicy(sessionEviction);
             }
         };
+        wac.setServer(server);
         JettyWebSocketServletContainerInitializer.configure(wac, null);
         wac.getSecurityHandler().setLoginService(loginService);
         wac.setThrowUnavailableOnStartupException(


### PR DESCRIPTION
This is a trivial change, and I'm not really sure what its purpose is, but it was in Olivier's experiment, and it can be safely pushed to trunk, so why not push it to trunk to shrink the size of the other diff.

### Testing done

`mvn clean verify`