### PR TITLE
[JENKINS-73285] Set maximum parameter count to 10,000 to match the documentation

### DIFF
--- a/src/main/java/winstone/HostConfiguration.java
+++ b/src/main/java/winstone/HostConfiguration.java
@@ -177,10 +177,7 @@ public class HostConfiguration {
                 } finally {
                     t.setContextClassLoader(ccl);
                 }
-                int maxParameterCount = Option.MAX_PARAM_COUNT.get(args);
-                if (maxParameterCount > 0) {
-                    setMaxFormKeys(maxParameterCount);
-                }
+                setMaxFormKeys(Option.MAX_PARAM_COUNT.get(args));
                 setMaxFormContentSize(Option.REQUEST_FORM_CONTENT_SIZE.get(args));
             }
 

--- a/src/main/java/winstone/cmdline/Option.java
+++ b/src/main/java/winstone/cmdline/Option.java
@@ -89,7 +89,7 @@ public class Option<T> {
 
     public static final OCompression COMPRESSION = new OCompression("compression", CompressionScheme.GZIP);
     public static final OString MIME_TYPES = string("mimeTypes");
-    public static final OInt MAX_PARAM_COUNT = integer("maxParamCount", -1);
+    public static final OInt MAX_PARAM_COUNT = integer("maxParamCount", 10000);
     public static final OBoolean USAGE = bool("usage", false);
     public static final OInt SESSION_TIMEOUT = integer("sessionTimeout", -1);
     public static final OInt SESSION_EVICTION = integer("sessionEviction", 1800);


### PR DESCRIPTION
The documentation states that the Winstone default is 10,000 (unlike the Jetty default of 1,000), but this statement is false, as Winstone only sets the value if the user specifies the option, and otherwise uses the Jetty default. Since Stapler forms are complex and often need thousands of parameters, this PR adjusts Winstone to match its own documentation and use a limit of 10,000.

### Testing done

- `mvn clean verify` passes, including the new automated test added in #393.
- Manually reproduced the scenario described in [JENKINS-73285](https://issues.jenkins.io/browse/JENKINS-73285) and verified that the issue was resolved after this PR on Jetty 12 EE 8.

Fixes jetty/jetty.project#11959