### PR TITLE
[JENKINS-73616] Log spam from `AnnotationParser#parseClass`

### DIFF
--- a/src/main/java/winstone/Launcher.java
+++ b/src/main/java/winstone/Launcher.java
@@ -39,6 +39,7 @@ import java.util.logging.ConsoleHandler;
 import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
+import org.eclipse.jetty.ee8.annotations.AnnotationParser;
 import org.eclipse.jetty.jmx.MBeanContainer;
 import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.LowResourceMonitor;
@@ -84,7 +85,7 @@ public class Launcher implements Runnable {
      * available protocol listeners.
      */
     @SuppressFBWarnings(
-            value = "DP_CREATE_CLASSLOADER_INSIDE_DO_PRIVILEGED",
+            value = {"DP_CREATE_CLASSLOADER_INSIDE_DO_PRIVILEGED", "LG_LOST_LOGGER_DUE_TO_WEAK_REFERENCE"},
             justification = "cf. https://github.com/spotbugs/spotbugs/issues/1515")
     public Launcher(Map<String, String> args) throws IOException {
         boolean success = false;
@@ -180,6 +181,10 @@ public class Launcher implements Runnable {
                 MBeanContainer mbeanContainer = new MBeanContainer(ManagementFactory.getPlatformMBeanServer());
                 server.addBean(mbeanContainer);
             }
+
+            // JENKINS-73616: Turn down log level of annotation parser
+            java.util.logging.Logger logger = java.util.logging.Logger.getLogger(AnnotationParser.class.getName());
+            logger.setLevel(Level.SEVERE);
 
             try {
                 server.start();


### PR DESCRIPTION
### Context

See [JENKINS-73616](https://issues.jenkins.io/browse/JENKINS-73616).

### Problem

Users have complained that there are new warnings emitted on Jenkins startup.

### Evaluation

These duplicates are known to the project and ignored in https://github.com/jenkinsci/jenkins/blob/c5c69abd2d346a694c29b3e5f5d3991d94c38556/test/src/test/java/jenkins/ClassPathTest.java because we cannot upgrade `jansi` without also upgrading Groovy as described in https://github.com/jenkinsci/jenkins/pull/5184#pullrequestreview-570261350 (though I doubt anyone has actually tried?).

### Solution

Since these warnings are a false positive, turn up the log level for this class from the default level to `SEVERE` so that this log statement is not printed.

### Testing done

Reproduced the issue with `java -jar jenkins.war` and could no longer reproduce after this PR.