### PR TITLE
[JENKINS-75278] Upgrade Jetty 12.0.17 which restore UriCompliance.LEGACY previous behaviour

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
   <properties>
     <revision>8.5</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jetty.version>12.0.16</jetty.version>
+    <jetty.version>12.0.17</jetty.version>
     <gitHubRepo>jenkinsci/winstone</gitHubRepo>
     <spotless.check.skip>false</spotless.check.skip>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -146,6 +146,16 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.eclipse.jetty.http2</groupId>
+      <artifactId>jetty-http2-client</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty.http2</groupId>
+      <artifactId>jetty-http2-client-transport</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.jenkins-ci</groupId>
       <artifactId>test-annotations</artifactId>
       <version>1.5</version>

--- a/src/main/java/winstone/HostConfiguration.java
+++ b/src/main/java/winstone/HostConfiguration.java
@@ -177,6 +177,7 @@ public class HostConfiguration {
                 }
                 setMaxFormKeys(Option.MAX_PARAM_COUNT.get(args));
                 setMaxFormContentSize(Option.REQUEST_FORM_CONTENT_SIZE.get(args));
+                // TODO ee10 getServletHandler().setDecodeAmbiguousURIs(true);
             }
 
             @Override

--- a/src/main/java/winstone/Http2ConnectorFactory.java
+++ b/src/main/java/winstone/Http2ConnectorFactory.java
@@ -20,6 +20,8 @@
 
 package winstone;
 
+import static winstone.ServerConnectorBuilder.DENY_SUSPICIOUS_PATH_CHARACTERS;
+
 import java.io.IOException;
 import java.util.Map;
 import java.util.logging.Level;
@@ -64,8 +66,11 @@ public class Http2ConnectorFactory extends AbstractSecuredConnectorFactory imple
             https_config.setSecureScheme("https");
             https_config.setSecurePort(listenPort);
             https_config.setHttpCompliance(HttpCompliance.RFC7230);
-            https_config.setUriCompliance(
-                    UriCompliance.LEGACY.with("winstone", UriCompliance.Violation.SUSPICIOUS_PATH_CHARACTERS));
+            UriCompliance compliance = UriCompliance.LEGACY;
+            if (!DENY_SUSPICIOUS_PATH_CHARACTERS) {
+                compliance = compliance.with("winstone", UriCompliance.Violation.SUSPICIOUS_PATH_CHARACTERS);
+            }
+            https_config.setUriCompliance(compliance);
             SecureRequestCustomizer secureRequestCustomizer = new SecureRequestCustomizer();
             secureRequestCustomizer.setSniHostCheck(Option.HTTPS_SNI_HOST_CHECK.get(args));
             https_config.addCustomizer(secureRequestCustomizer);

--- a/src/main/java/winstone/Http2ConnectorFactory.java
+++ b/src/main/java/winstone/Http2ConnectorFactory.java
@@ -64,15 +64,8 @@ public class Http2ConnectorFactory extends AbstractSecuredConnectorFactory imple
             https_config.setSecureScheme("https");
             https_config.setSecurePort(listenPort);
             https_config.setHttpCompliance(HttpCompliance.RFC7230);
-            // https_config.setUriCompliance(UriCompliance.LEGACY);
             https_config.setUriCompliance(
-                    UriCompliance.LEGACY.with("winstone", UriCompliance.Violation.SUSPICIOUS_PATH_CHARACTERS /*,
-                    UriCompliance.Violation.AMBIGUOUS_PATH_SEGMENT,
-                    UriCompliance.Violation.AMBIGUOUS_PATH_SEPARATOR,
-                    UriCompliance.Violation.AMBIGUOUS_PATH_ENCODING,
-                    UriCompliance.Violation.AMBIGUOUS_EMPTY_SEGMENT,
-                    UriCompliance.Violation.UTF16_ENCODINGS,
-                    UriCompliance.Violation.USER_INFO*/));
+                    UriCompliance.LEGACY.with("winstone", UriCompliance.Violation.SUSPICIOUS_PATH_CHARACTERS));
             SecureRequestCustomizer secureRequestCustomizer = new SecureRequestCustomizer();
             secureRequestCustomizer.setSniHostCheck(Option.HTTPS_SNI_HOST_CHECK.get(args));
             https_config.addCustomizer(secureRequestCustomizer);

--- a/src/main/java/winstone/Http2ConnectorFactory.java
+++ b/src/main/java/winstone/Http2ConnectorFactory.java
@@ -64,7 +64,15 @@ public class Http2ConnectorFactory extends AbstractSecuredConnectorFactory imple
             https_config.setSecureScheme("https");
             https_config.setSecurePort(listenPort);
             https_config.setHttpCompliance(HttpCompliance.RFC7230);
-            https_config.setUriCompliance(UriCompliance.LEGACY);
+            // https_config.setUriCompliance(UriCompliance.LEGACY);
+            https_config.setUriCompliance(
+                    UriCompliance.LEGACY.with("winstone", UriCompliance.Violation.SUSPICIOUS_PATH_CHARACTERS /*,
+                    UriCompliance.Violation.AMBIGUOUS_PATH_SEGMENT,
+                    UriCompliance.Violation.AMBIGUOUS_PATH_SEPARATOR,
+                    UriCompliance.Violation.AMBIGUOUS_PATH_ENCODING,
+                    UriCompliance.Violation.AMBIGUOUS_EMPTY_SEGMENT,
+                    UriCompliance.Violation.UTF16_ENCODINGS,
+                    UriCompliance.Violation.USER_INFO*/));
             SecureRequestCustomizer secureRequestCustomizer = new SecureRequestCustomizer();
             secureRequestCustomizer.setSniHostCheck(Option.HTTPS_SNI_HOST_CHECK.get(args));
             https_config.addCustomizer(secureRequestCustomizer);
@@ -92,7 +100,6 @@ public class Http2ConnectorFactory extends AbstractSecuredConnectorFactory imple
             http2Connector.setHost(listenAddress);
             server.addConnector(http2Connector);
             server.setDumpAfterStart(Boolean.getBoolean("dumpAfterStart"));
-
             return http2Connector;
         } catch (IllegalStateException e) {
             Logger.log(Level.WARNING, Launcher.RESOURCES, "Http2ConnectorFactory.FailedStart.ALPN", e);

--- a/src/main/java/winstone/Http2ConnectorFactory.java
+++ b/src/main/java/winstone/Http2ConnectorFactory.java
@@ -20,8 +20,6 @@
 
 package winstone;
 
-import static winstone.ServerConnectorBuilder.DENY_SUSPICIOUS_PATH_CHARACTERS;
-
 import java.io.IOException;
 import java.util.Map;
 import java.util.logging.Level;
@@ -66,11 +64,7 @@ public class Http2ConnectorFactory extends AbstractSecuredConnectorFactory imple
             https_config.setSecureScheme("https");
             https_config.setSecurePort(listenPort);
             https_config.setHttpCompliance(HttpCompliance.RFC7230);
-            UriCompliance compliance = UriCompliance.LEGACY;
-            if (!DENY_SUSPICIOUS_PATH_CHARACTERS) {
-                compliance = compliance.with("winstone", UriCompliance.Violation.SUSPICIOUS_PATH_CHARACTERS);
-            }
-            https_config.setUriCompliance(compliance);
+            https_config.setUriCompliance(UriCompliance.LEGACY);
             SecureRequestCustomizer secureRequestCustomizer = new SecureRequestCustomizer();
             secureRequestCustomizer.setSniHostCheck(Option.HTTPS_SNI_HOST_CHECK.get(args));
             https_config.addCustomizer(secureRequestCustomizer);

--- a/src/main/java/winstone/ServerConnectorBuilder.java
+++ b/src/main/java/winstone/ServerConnectorBuilder.java
@@ -15,6 +15,9 @@ import org.eclipse.jetty.util.ssl.SslContextFactory;
 
 class ServerConnectorBuilder {
 
+    public static boolean DENY_SUSPICIOUS_PATH_CHARACTERS =
+            Boolean.getBoolean("winstone.DENY_SUSPICIOUS_PATH_CHARACTERS");
+
     private int listenerPort;
     private int secureListenerPort;
     private int keepAliveTimeout;
@@ -132,7 +135,11 @@ class ServerConnectorBuilder {
             hc.setSecurePort(secureListenerPort);
         }
         hc.setHttpCompliance(HttpCompliance.RFC7230);
-        hc.setUriCompliance(UriCompliance.LEGACY.with("winstone", UriCompliance.Violation.SUSPICIOUS_PATH_CHARACTERS));
+        UriCompliance compliance = UriCompliance.LEGACY;
+        if (!DENY_SUSPICIOUS_PATH_CHARACTERS) {
+            compliance = compliance.with("winstone", UriCompliance.Violation.SUSPICIOUS_PATH_CHARACTERS);
+        }
+        hc.setUriCompliance(compliance);
         hc.addCustomizer(new ForwardedRequestCustomizer());
         hc.setRequestHeaderSize(requestHeaderSize);
         hc.setResponseHeaderSize(responseHeaderSize);

--- a/src/main/java/winstone/ServerConnectorBuilder.java
+++ b/src/main/java/winstone/ServerConnectorBuilder.java
@@ -15,9 +15,6 @@ import org.eclipse.jetty.util.ssl.SslContextFactory;
 
 class ServerConnectorBuilder {
 
-    public static boolean DENY_SUSPICIOUS_PATH_CHARACTERS =
-            Boolean.getBoolean("winstone.DENY_SUSPICIOUS_PATH_CHARACTERS");
-
     private int listenerPort;
     private int secureListenerPort;
     private int keepAliveTimeout;
@@ -135,11 +132,7 @@ class ServerConnectorBuilder {
             hc.setSecurePort(secureListenerPort);
         }
         hc.setHttpCompliance(HttpCompliance.RFC7230);
-        UriCompliance compliance = UriCompliance.LEGACY;
-        if (!DENY_SUSPICIOUS_PATH_CHARACTERS) {
-            compliance = compliance.with("winstone", UriCompliance.Violation.SUSPICIOUS_PATH_CHARACTERS);
-        }
-        hc.setUriCompliance(compliance);
+        hc.setUriCompliance(UriCompliance.LEGACY);
         hc.addCustomizer(new ForwardedRequestCustomizer());
         hc.setRequestHeaderSize(requestHeaderSize);
         hc.setResponseHeaderSize(responseHeaderSize);

--- a/src/main/java/winstone/ServerConnectorBuilder.java
+++ b/src/main/java/winstone/ServerConnectorBuilder.java
@@ -132,7 +132,7 @@ class ServerConnectorBuilder {
             hc.setSecurePort(secureListenerPort);
         }
         hc.setHttpCompliance(HttpCompliance.RFC7230);
-        hc.setUriCompliance(UriCompliance.LEGACY);
+        hc.setUriCompliance(UriCompliance.LEGACY.with("winstone", UriCompliance.Violation.SUSPICIOUS_PATH_CHARACTERS));
         hc.addCustomizer(new ForwardedRequestCustomizer());
         hc.setRequestHeaderSize(requestHeaderSize);
         hc.setResponseHeaderSize(responseHeaderSize);

--- a/src/test/java/winstone/AbstractWinstoneTest.java
+++ b/src/test/java/winstone/AbstractWinstoneTest.java
@@ -63,6 +63,19 @@ public class AbstractWinstoneTest {
      * @throws Exception
      */
     public String makeRequest(String path, String url, Protocol protocol) throws Exception {
+        return makeRequest(path, url, HttpStatus.OK_200, protocol);
+    }
+
+    /**
+     *
+     * @param path path to unix domain socket (can be null if not using unix domain socket)
+     * @param url the URL to request
+     * @param expectedHttpStatus the expected http response code from the server
+     * @param protocol see #Protocol
+     * @return the response
+     * @throws Exception
+     */
+    public String makeRequest(String path, String url, int expectedHttpStatus, Protocol protocol) throws Exception {
 
         HttpClient httpClient = getHttpClient(path);
 
@@ -78,7 +91,7 @@ public class AbstractWinstoneTest {
 
         httpClient.stop();
 
-        assertEquals(HttpStatus.OK_200, response.getStatus());
+        assertEquals(expectedHttpStatus, response.getStatus());
         return response.getContentAsString();
     }
 

--- a/src/test/java/winstone/AbstractWinstoneTest.java
+++ b/src/test/java/winstone/AbstractWinstoneTest.java
@@ -8,9 +8,16 @@ import java.net.Socket;
 import java.nio.file.Path;
 import org.eclipse.jetty.client.ContentResponse;
 import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.Request;
+import org.eclipse.jetty.client.transport.HttpClientConnectionFactory;
 import org.eclipse.jetty.client.transport.HttpClientTransportDynamic;
 import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.http.HttpVersion;
+import org.eclipse.jetty.http2.client.HTTP2Client;
+import org.eclipse.jetty.http2.client.transport.ClientConnectionFactoryOverHTTP2;
+import org.eclipse.jetty.io.ClientConnectionFactory;
 import org.eclipse.jetty.io.ClientConnector;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.junit.After;
 
 /**
@@ -26,24 +33,71 @@ public class AbstractWinstoneTest {
         }
     }
 
-    public String makeRequest(String url) throws Exception {
-        return makeRequest(null, url);
+    enum Protocol {
+        HTTP_1,
+        HTTP_2;
     }
 
+    /**
+     * please use {@link #makeRequest(String, String, Protocol)}
+     */
+    @Deprecated
+    public String makeRequest(String url) throws Exception {
+        return makeRequest(null, url, Protocol.HTTP_1);
+    }
+
+    /**
+     * please use {@link #makeRequest(String, String, Protocol)}
+     */
+    @Deprecated
     public String makeRequest(String path, String url) throws Exception {
+        return makeRequest(path, url, Protocol.HTTP_1);
+    }
+
+    /**
+     *
+     * @param path path to unix domain socket (can be null if not using unix domain socket)
+     * @param url the URL to request
+     * @param protocol see #Protocol
+     * @return the response
+     * @throws Exception
+     */
+    public String makeRequest(String path, String url, Protocol protocol) throws Exception {
 
         HttpClient httpClient;
 
+        ClientConnector connector;
+
         if (path != null) {
             Path unixDomainPath = Path.of(path);
-            ClientConnector clientConnector = ClientConnector.forUnixDomain(unixDomainPath);
-            httpClient = new HttpClient(new HttpClientTransportDynamic(clientConnector));
+            connector = ClientConnector.forUnixDomain(unixDomainPath);
         } else {
-            httpClient = new HttpClient();
+            SslContextFactory.Client sslContextFactory = new SslContextFactory.Client(true);
+            sslContextFactory.setHostnameVerifier((hostname, session) -> true);
+
+            connector = new ClientConnector();
+            connector.setSslContextFactory(sslContextFactory);
         }
+
+        ClientConnectionFactory.Info http1 = HttpClientConnectionFactory.HTTP11;
+
+        HTTP2Client http2Client = new HTTP2Client(connector);
+        ClientConnectionFactoryOverHTTP2.HTTP2 http2 = new ClientConnectionFactoryOverHTTP2.HTTP2(http2Client);
+
+        HttpClientTransportDynamic transport = new HttpClientTransportDynamic(connector, http1, http2);
+        httpClient = new HttpClient(transport);
+
         httpClient.start();
 
-        ContentResponse response = httpClient.GET(url);
+        Request request = httpClient.newRequest(url);
+
+        switch (protocol) {
+            case HTTP_1 -> request.version(HttpVersion.HTTP_1_1);
+            case HTTP_2 -> request.version(HttpVersion.HTTP_2);
+            default -> throw new Exception("Unsupported Http Version: " + protocol);
+        }
+
+        ContentResponse response = request.send();
 
         httpClient.stop();
 

--- a/src/test/java/winstone/Http2ConnectorFactoryTest.java
+++ b/src/test/java/winstone/Http2ConnectorFactoryTest.java
@@ -24,11 +24,11 @@ public class Http2ConnectorFactoryTest extends AbstractWinstoneTest {
 
     private static final String DISABLE_HOSTNAME_VERIFICATION = "jdk.internal.httpclient.disableHostnameVerification";
 
-    private String request(X509TrustManager tm, int port) throws Exception {
+    private String request(X509TrustManager tm, URI uri) throws Exception {
         String disableHostnameVerification = System.getProperty(DISABLE_HOSTNAME_VERIFICATION);
         try {
             System.setProperty(DISABLE_HOSTNAME_VERIFICATION, Boolean.TRUE.toString());
-            HttpRequest request = HttpRequest.newBuilder(new URI("https://localhost:" + port + "/CountRequestsServlet"))
+            HttpRequest request = HttpRequest.newBuilder(uri)
                     .version(HttpClient.Version.HTTP_2)
                     .GET()
                     .build();
@@ -62,7 +62,7 @@ public class Http2ConnectorFactoryTest extends AbstractWinstoneTest {
         assertConnectionRefused("127.0.0.2", port);
         assertEquals(
                 "<html><body>This servlet has been accessed via GET 1001 times</body></html>\r\n",
-                request(new TrustEveryoneManager(), port));
+                request(new TrustEveryoneManager(), new URI("https://localhost:" + port + "/CountRequestsServlet")));
         LowResourceMonitor lowResourceMonitor = winstone.server.getBean(LowResourceMonitor.class);
         assertNotNull(lowResourceMonitor);
         assertFalse(lowResourceMonitor.isLowOnResources());
@@ -84,11 +84,13 @@ public class Http2ConnectorFactoryTest extends AbstractWinstoneTest {
 
         assertEquals(
                 "<html><body>Hello winstone </body></html>\r\n",
-                makeRequest("http://127.0.0.1:" + port + "/hello/winstone"));
+                request(new TrustEveryoneManager(), new URI("https://127.0.0.1:" + port + "/hello/winstone")));
 
         assertEquals(
                 "<html><body>Hello win\\stone </body></html>\r\n",
-                makeRequest("http://127.0.0.1:" + port + "/hello/"
-                        + URLEncoder.encode("win\\stone", StandardCharsets.UTF_8))); // %5C == \
+                request(
+                        new TrustEveryoneManager(),
+                        new URI("https://127.0.0.1:" + port + "/hello/"
+                                + URLEncoder.encode("win\\stone", StandardCharsets.UTF_8)))); // %5C == \
     }
 }

--- a/src/test/java/winstone/Http2ConnectorFactoryTest.java
+++ b/src/test/java/winstone/Http2ConnectorFactoryTest.java
@@ -1,7 +1,5 @@
 package winstone;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.StringContains.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -11,7 +9,6 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
-import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.server.LowResourceMonitor;
 import org.eclipse.jetty.server.ServerConnector;
 import org.junit.Test;
@@ -64,17 +61,5 @@ public class Http2ConnectorFactoryTest extends AbstractWinstoneTest {
                         "https://127.0.0.1:" + port + "/hello/"
                                 + URLEncoder.encode("win\\stone", StandardCharsets.UTF_8),
                         Protocol.HTTP_2)); // %5C == \
-        // Escape hatch
-        ServerConnectorBuilder.DENY_SUSPICIOUS_PATH_CHARACTERS = true;
-        winstone = new Launcher(args);
-        port = ((ServerConnector) winstone.server.getConnectors()[0]).getLocalPort();
-        assertThat(
-                makeRequest(
-                        null,
-                        "https://127.0.0.1:" + port + "/hello/"
-                                + URLEncoder.encode("win\\stone", StandardCharsets.UTF_8),
-                        HttpStatus.BAD_REQUEST_400,
-                        Protocol.HTTP_2),
-                containsString("HTTP ERROR 400 Suspicious Path Character")); // %5C == \
     }
 }

--- a/src/test/java/winstone/HttpConnectorFactoryTest.java
+++ b/src/test/java/winstone/HttpConnectorFactoryTest.java
@@ -1,5 +1,7 @@
 package winstone;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.StringContains.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -19,6 +21,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import org.awaitility.Awaitility;
+import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.server.LowResourceMonitor;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.unixdomain.server.UnixDomainServerConnector;
@@ -131,5 +134,18 @@ public class HttpConnectorFactoryTest extends AbstractWinstoneTest {
                 "<html><body>Hello win\\stone </body></html>\r\n",
                 makeRequest("http://127.0.0.1:" + port + "/hello/"
                         + URLEncoder.encode("win\\stone", StandardCharsets.UTF_8))); // %5C == \
+
+        // Escape hatch
+        ServerConnectorBuilder.DENY_SUSPICIOUS_PATH_CHARACTERS = true;
+        winstone = new Launcher(args);
+        port = ((ServerConnector) winstone.server.getConnectors()[0]).getLocalPort();
+        assertThat(
+                makeRequest(
+                        null,
+                        "http://127.0.0.1:" + port + "/hello/"
+                                + URLEncoder.encode("win\\stone", StandardCharsets.UTF_8),
+                        HttpStatus.BAD_REQUEST_400,
+                        Protocol.HTTP_1),
+                containsString("HTTP ERROR 400 Suspicious Path Character")); // %5C == \
     }
 }

--- a/src/test/java/winstone/HttpConnectorFactoryTest.java
+++ b/src/test/java/winstone/HttpConnectorFactoryTest.java
@@ -1,7 +1,5 @@
 package winstone;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.StringContains.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -21,7 +19,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import org.awaitility.Awaitility;
-import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.server.LowResourceMonitor;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.unixdomain.server.UnixDomainServerConnector;
@@ -134,18 +131,5 @@ public class HttpConnectorFactoryTest extends AbstractWinstoneTest {
                 "<html><body>Hello win\\stone </body></html>\r\n",
                 makeRequest("http://127.0.0.1:" + port + "/hello/"
                         + URLEncoder.encode("win\\stone", StandardCharsets.UTF_8))); // %5C == \
-
-        // Escape hatch
-        ServerConnectorBuilder.DENY_SUSPICIOUS_PATH_CHARACTERS = true;
-        winstone = new Launcher(args);
-        port = ((ServerConnector) winstone.server.getConnectors()[0]).getLocalPort();
-        assertThat(
-                makeRequest(
-                        null,
-                        "http://127.0.0.1:" + port + "/hello/"
-                                + URLEncoder.encode("win\\stone", StandardCharsets.UTF_8),
-                        HttpStatus.BAD_REQUEST_400,
-                        Protocol.HTTP_1),
-                containsString("HTTP ERROR 400 Suspicious Path Character")); // %5C == \
     }
 }

--- a/src/test/java/winstone/testApplication/servlets/HelloRestOfPathServlet.java
+++ b/src/test/java/winstone/testApplication/servlets/HelloRestOfPathServlet.java
@@ -1,0 +1,18 @@
+package winstone.testApplication.servlets;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class HelloRestOfPathServlet extends HttpServlet {
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        ServletOutputStream out = resp.getOutputStream();
+        out.println("<html><body>Hello " + req.getPathInfo().trim().replaceFirst("/", "") + " </body></html>");
+        out.flush();
+    }
+}

--- a/src/testwebapp/WEB-INF/web.xml
+++ b/src/testwebapp/WEB-INF/web.xml
@@ -68,6 +68,11 @@
 		</init-param>
 	</servlet>
 
+	<servlet>
+		<servlet-name>HelloServlet</servlet-name>
+		<servlet-class>winstone.testApplication.servlets.HelloRestOfPathServlet</servlet-class>
+	</servlet>
+
   <!-- testing load on startup of a jsp -->
 	<servlet>
 		<servlet-name>loadOnStartupJSP</servlet-name>
@@ -115,6 +120,11 @@
 	<servlet-mapping>
 		<servlet-name>CountRequestsServlet</servlet-name>
 		<url-pattern>/TestWriteAfterServlet</url-pattern>
+	</servlet-mapping>
+
+	<servlet-mapping>
+		<servlet-name>HelloServlet</servlet-name>
+		<url-pattern>/hello/*</url-pattern>
 	</servlet-mapping>
 
 	<!-- Test the welcome file processing order -->


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

### Testing done

Unit tests written. But I can't get the http2 connector test to work, it fails with whatever uri compliance I set. Is it perhaps not possible in the http2 spec?

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
