### PR TITLE
Remove usages of deprecated functionality

### DIFF
--- a/src/test/java/winstone/Http2ConnectorFactoryTest.java
+++ b/src/test/java/winstone/Http2ConnectorFactoryTest.java
@@ -30,7 +30,7 @@ public class Http2ConnectorFactoryTest extends AbstractWinstoneTest {
         assertConnectionRefused("127.0.0.2", port);
         assertEquals(
                 "<html><body>This servlet has been accessed via GET 1001 times</body></html>\r\n",
-                makeRequest(null, "https://localhost:" + port + "/CountRequestsServlet", Protocol.HTTP_2));
+                makeRequest("https://localhost:" + port + "/CountRequestsServlet", Protocol.HTTP_2));
         LowResourceMonitor lowResourceMonitor = winstone.server.getBean(LowResourceMonitor.class);
         assertNotNull(lowResourceMonitor);
         assertFalse(lowResourceMonitor.isLowOnResources());
@@ -52,12 +52,11 @@ public class Http2ConnectorFactoryTest extends AbstractWinstoneTest {
 
         assertEquals(
                 "<html><body>Hello winstone </body></html>\r\n",
-                makeRequest(null, "https://127.0.0.1:" + port + "/hello/winstone", Protocol.HTTP_2));
+                makeRequest("https://127.0.0.1:" + port + "/hello/winstone", Protocol.HTTP_2));
 
         assertEquals(
                 "<html><body>Hello win\\stone </body></html>\r\n",
                 makeRequest(
-                        null,
                         "https://127.0.0.1:" + port + "/hello/"
                                 + URLEncoder.encode("win\\stone", StandardCharsets.UTF_8),
                         Protocol.HTTP_2)); // %5C == \

--- a/src/test/java/winstone/HttpConnectorFactoryTest.java
+++ b/src/test/java/winstone/HttpConnectorFactoryTest.java
@@ -57,7 +57,7 @@ public class HttpConnectorFactoryTest extends AbstractWinstoneTest {
 
         assertEquals(
                 "<html><body>This servlet has been accessed via GET 1001 times</body></html>\r\n",
-                makeRequest(path, "http://127.0.0.1:80/CountRequestsServlet"));
+                makeRequest(path, "http://127.0.0.1:80/CountRequestsServlet", Protocol.HTTP_1));
 
         LowResourceMonitor lowResourceMonitor = winstone.server.getBean(LowResourceMonitor.class);
         assertNotNull(lowResourceMonitor);
@@ -79,7 +79,7 @@ public class HttpConnectorFactoryTest extends AbstractWinstoneTest {
 
         assertEquals(
                 "<html><body>This servlet has been accessed via GET 1001 times</body></html>\r\n",
-                makeRequest("http://127.0.0.2:" + port + "/CountRequestsServlet"));
+                makeRequest("http://127.0.0.2:" + port + "/CountRequestsServlet", Protocol.HTTP_1));
 
         LowResourceMonitor lowResourceMonitor = winstone.server.getBean(LowResourceMonitor.class);
         assertNotNull(lowResourceMonitor);
@@ -125,11 +125,14 @@ public class HttpConnectorFactoryTest extends AbstractWinstoneTest {
 
         assertEquals(
                 "<html><body>Hello winstone </body></html>\r\n",
-                makeRequest("http://127.0.0.1:" + port + "/hello/winstone"));
+                makeRequest("http://127.0.0.1:" + port + "/hello/winstone", Protocol.HTTP_1));
 
+        // %5C == \
         assertEquals(
                 "<html><body>Hello win\\stone </body></html>\r\n",
-                makeRequest("http://127.0.0.1:" + port + "/hello/"
-                        + URLEncoder.encode("win\\stone", StandardCharsets.UTF_8))); // %5C == \
+                makeRequest(
+                        "http://127.0.0.1:" + port + "/hello/"
+                                + URLEncoder.encode("win\\stone", StandardCharsets.UTF_8),
+                        Protocol.HTTP_1));
     }
 }

--- a/src/test/java/winstone/HttpsConnectorFactoryTest.java
+++ b/src/test/java/winstone/HttpsConnectorFactoryTest.java
@@ -40,7 +40,7 @@ public class HttpsConnectorFactoryTest extends AbstractWinstoneTest {
         assertConnectionRefused("127.0.0.2", port);
         assertEquals(
                 "<html><body>This servlet has been accessed via GET 1001 times</body></html>\r\n",
-                makeRequest(null, "https://localhost:" + port + "/CountRequestsServlet", Protocol.HTTP_1));
+                makeRequest("https://localhost:" + port + "/CountRequestsServlet", Protocol.HTTP_1));
         LowResourceMonitor lowResourceMonitor = winstone.server.getBean(LowResourceMonitor.class);
         assertNotNull(lowResourceMonitor);
         assertFalse(lowResourceMonitor.isLowOnResources());
@@ -85,11 +85,11 @@ public class HttpsConnectorFactoryTest extends AbstractWinstoneTest {
         // also verify that directly accessing the resource works.
         assertEquals(
                 "<html><body>This servlet has been accessed via GET 1002 times</body></html>\r\n",
-                makeRequest(null, "https://localhost:" + httpsPort + "/CountRequestsServlet", Protocol.HTTP_1));
+                makeRequest("https://localhost:" + httpsPort + "/CountRequestsServlet", Protocol.HTTP_1));
     }
 
     private String requestRedirect(int httpPort) throws Exception {
-        HttpClient httpClient = getHttpClient(null);
+        HttpClient httpClient = getHttpClient();
         try {
             ContentResponse contentResponse = httpClient.GET("http://localhost:" + httpPort + "/CountRequestsServlet");
             assertEquals(HttpURLConnection.HTTP_MOVED_TEMP, contentResponse.getStatus());

--- a/src/test/java/winstone/accesslog/SimpleAccessLoggerTest.java
+++ b/src/test/java/winstone/accesslog/SimpleAccessLoggerTest.java
@@ -38,8 +38,7 @@ public class SimpleAccessLoggerTest extends AbstractWinstoneTest {
         // make a request
         assertEquals(
                 "<html><body>This servlet has been accessed via GET 1001 times</body></html>\r\n",
-                makeRequest("http://localhost:" + port + "/examples/CountRequestsServlet"));
-
+                makeRequest("http://localhost:" + port + "/examples/CountRequestsServlet", Protocol.HTTP_1));
         // check the log file
         // check the log file every 100ms for 5s
         String text = "";


### PR DESCRIPTION
`ClientConnector#forUnixDomain` is deprecated for removal in Jetty 12.1, so replace this with the non-deprecated equivalent `Transport.TCPUnix`. While I was here, I also removed two deprecated test methods and refactored test usage to be more consistent throughout all tests.

### Testing done

`mvn clean verify`, including  `HttpConnectorFactoryTest#testListenUnixDomainPath`

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
