### PR TITLE
Add support for Brotli and Zstandard compression

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ To run locally exploded web archive:
                                "^.*_anon_.*$" 
        --controlPort            = set the shutdown/control port. -1 to disable, Default disabled
     
-       --compression            = set the compression scheme (gzip or none to disable compression). Default is gzip.
+       --compression            = set the compression scheme (brotli, gzip, zstd, or none to disable compression). Default is gzip.
        --sessionTimeout         = set the http session timeout value in minutes. Default to what webapp specifies, and then to 60 minutes
        --sessionEviction        = set the session eviction timeout for idle sessions in seconds. Default value is 180. -1 never evict, 0 evict on exit
        --mimeTypes=ARG          = define additional MIME type mappings. ARG would be EXT=MIMETYPE:EXT=MIMETYPE:...

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
   <properties>
     <revision>8.8</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jetty.version>12.0.19</jetty.version>
+    <jetty.version>12.1.0.alpha2</jetty.version>
     <gitHubRepo>jenkinsci/winstone</gitHubRepo>
     <spotless.check.skip>false</spotless.check.skip>
   </properties>
@@ -108,6 +108,26 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-util</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty.compression</groupId>
+      <artifactId>jetty-compression-brotli</artifactId>
+      <version>${jetty.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty.compression</groupId>
+      <artifactId>jetty-compression-gzip</artifactId>
+      <version>${jetty.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty.compression</groupId>
+      <artifactId>jetty-compression-server</artifactId>
+      <version>${jetty.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty.compression</groupId>
+      <artifactId>jetty-compression-zstandard</artifactId>
+      <version>${jetty.version}</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.ee9</groupId>

--- a/src/main/java/winstone/HostConfiguration.java
+++ b/src/main/java/winstone/HostConfiguration.java
@@ -30,12 +30,15 @@ import java.util.StringTokenizer;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.logging.Level;
+import org.eclipse.jetty.compression.brotli.BrotliCompression;
+import org.eclipse.jetty.compression.gzip.GzipCompression;
+import org.eclipse.jetty.compression.server.CompressionHandler;
+import org.eclipse.jetty.compression.zstandard.ZstandardCompression;
 import org.eclipse.jetty.ee9.webapp.WebAppContext;
 import org.eclipse.jetty.ee9.websocket.server.config.JettyWebSocketServletContainerInitializer;
 import org.eclipse.jetty.security.LoginService;
 import org.eclipse.jetty.server.RequestLog;
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.handler.gzip.GzipHandler;
 import winstone.cmdline.CompressionScheme;
 import winstone.cmdline.Option;
 
@@ -107,10 +110,23 @@ public class HostConfiguration {
 
         CompressionScheme compressionScheme = Option.COMPRESSION.get(this.args);
         switch (compressionScheme) {
+            case BROTLI:
+                CompressionHandler brotliHandler = new CompressionHandler();
+                brotliHandler.putCompression(new BrotliCompression());
+                brotliHandler.setHandler(webAppContext);
+                server.setHandler(brotliHandler);
+                break;
             case GZIP:
-                GzipHandler gzipHandler = new GzipHandler();
+                CompressionHandler gzipHandler = new CompressionHandler();
+                gzipHandler.putCompression(new GzipCompression());
                 gzipHandler.setHandler(webAppContext);
                 server.setHandler(gzipHandler);
+                break;
+            case ZSTD:
+                CompressionHandler zstdHandler = new CompressionHandler();
+                zstdHandler.putCompression(new ZstandardCompression());
+                zstdHandler.setHandler(webAppContext);
+                server.setHandler(zstdHandler);
                 break;
             case NONE:
                 server.setHandler(webAppContext);

--- a/src/main/java/winstone/cmdline/CompressionScheme.java
+++ b/src/main/java/winstone/cmdline/CompressionScheme.java
@@ -5,6 +5,8 @@ package winstone.cmdline;
  * compression schemes is added to Jetty upstream.
  */
 public enum CompressionScheme {
+    BROTLI,
     GZIP,
+    ZSTD,
     NONE,
 }

--- a/src/main/java/winstone/cmdline/Option.java
+++ b/src/main/java/winstone/cmdline/Option.java
@@ -322,8 +322,12 @@ public class Option<T> {
             CompressionScheme compressionScheme;
             if (v == null) {
                 compressionScheme = defaultValue;
+            } else if (v.equalsIgnoreCase("brotli")) {
+                compressionScheme = CompressionScheme.BROTLI;
             } else if (v.equalsIgnoreCase("gzip")) {
                 compressionScheme = CompressionScheme.GZIP;
+            } else if (v.equalsIgnoreCase("zstd")) {
+                compressionScheme = CompressionScheme.ZSTD;
             } else if (v.equalsIgnoreCase("none")) {
                 compressionScheme = CompressionScheme.NONE;
             } else {

--- a/src/main/resources/winstone/LocalStrings.properties
+++ b/src/main/resources/winstone/LocalStrings.properties
@@ -87,7 +87,7 @@ Launcher.UsageInstructions.Options=\
 \                           "^.*_NULL_.*$", \n\
 \                           "^.*_anon_.*$" \n\
 \   --controlPort            = set the shutdown/control port. -1 to disable, Default disabled\n\n\
-\   --compression            = set the compression scheme (gzip or none to disable compression). Default is gzip.\n\
+\   --compression            = set the compression scheme (brotli, gzip, zstd, or none to disable compression). Default is gzip.\n\
 \   --sessionTimeout         = set the http session timeout value in minutes. Default to what webapp specifies, and then to 60 minutes\n\
 \   --sessionEviction        = set the session eviction timeout for idle sessions in seconds. Default value is 180. -1 never evict, 0 evict on exit\n\
 \   --mimeTypes=ARG          = define additional MIME type mappings. ARG would be EXT=MIMETYPE:EXT=MIMETYPE:...\n\


### PR DESCRIPTION
Experimenting with the new support for Brotli and Zstandard in Jetty 12.1.x.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
