### PR TITLE
System property for setting logging shutdown timeout

### DIFF
--- a/src/main/java/winstone/Launcher.java
+++ b/src/main/java/winstone/Launcher.java
@@ -71,8 +71,8 @@ public class Launcher implements Runnable {
      * Timeout (in milliseconds) for logging system shutdown after shutdown hooks trigger.
      * Default is 30s, matching Kubernetes `terminationGracePeriodSeconds`.
      */
-    private static int SHUTDOWN_TIMEOUT = Integer.parseInt(
-        System.getProperty("winstone.Launcher.loggingShutdownTimeoutSeconds", "30")) * 1000;
+    private static int SHUTDOWN_TIMEOUT =
+            Integer.parseInt(System.getProperty("winstone.Launcher.loggingShutdownTimeoutSeconds", "30")) * 1000;
 
     private Thread controlThread;
     public static final WinstoneResourceBundle RESOURCES = new WinstoneResourceBundle("winstone.LocalStrings");


### PR DESCRIPTION
The logging facility shutdown timeout is currently fixed at 20s - jenkinsci/winstone#310.

This can be insufficient in environments like Kubernetes, where the default `terminationGracePeriodSeconds` is 30s. This mismatch can cause premature log termination during shutdown. Furthermore, large Jenkins controllers may require even more than 30s to shut down gracefully.

This PR proposes to change default timeout to 30s (aligning with k8s default `terminationGracePeriodSeconds`) and proposes a system property, so users can set higher timeouts if required.

### Testing done

Starting jenkins by `java -jar war/target/jenkins.war` stop by `CTRL + C`.

Tested by sleep 25s, 30s, 33s by patching Jenkins core shutdown phase.

<details><summary>example diff of 30s</summary>

```diff
diff --git a/core/src/main/java/jenkins/model/Jenkins.java b/core/src/main/java/jenkins/model/Jenkins.java
index 3babff393b..a92a79cdac 100644
--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -3645,6 +3645,9 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
             cleanUpStarted = true;
         }
         try {
+            System.out.println("Sleeping 30 seconds before shutdown...");
+            TimeUnit.SECONDS.sleep(30);
+            System.out.println("Waking up, proceeding with shutdown, no more logs...");
             getLifecycle().onStatusUpdate("Stopping Jenkins");

             final List<Throwable> errors = new ArrayList<>();
@@ -3696,6 +3699,8 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
                 }
                 throw exception;
             }
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
         } finally {
             theInstance = null;
             if (JenkinsJVM.isJenkinsJVM()) {
diff --git a/pom.xml b/pom.xml
index fc1636cd14..2c33b5e503 100644
--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@ THE SOFTWARE.
     <spotless.check.skip>false</spotless.check.skip>
     <ban-junit4-imports.skip>false</ban-junit4-imports.skip>
     <!-- Make sure to keep the jetty-ee9-maven-plugin version in war/pom.xml in sync with the Jetty release in Winstone: -->
-    <winstone.version>8.16</winstone.version>
+    <winstone.version>8.17-SNAPSHOT</winstone.version>
     <node.version>24.9.0</node.version>
   </properties>
```

</details>

With 30s being shutdown sleep, and 30s being logging system shutdown timeout, no logs printed,
```
→ java -jar war/target/jenkins.war
...
2025-11-03 16:57:37.367+0000 [id=49]	INFO	jenkins.InitReactorRunner$1#onAttained: Completed initialization
2025-11-03 16:57:37.382+0000 [id=26]	INFO	hudson.lifecycle.Lifecycle#onReady: Jenkins is fully up and running
^C2025-11-03 16:57:44.090+0000 [id=29]	INFO	winstone.Logger#logInternal: JVM is terminating. Shutting down Jetty
2025-11-03 16:57:44.092+0000 [id=29]	INFO	org.eclipse.jetty.server.Server#doStop: Stopped oejs.Server@566d0c69{STOPPING}[12.1.3,sto=0]
2025-11-03 16:57:44.098+0000 [id=29]	INFO	o.e.j.server.AbstractConnector#doStop: Stopped oejs.ServerConnector@49aa766b{HTTP/1.1, (http/1.1)}{0.0.0.0:8080}
Sleeping 30 seconds before shutdown...
Waking up, proceeding with shutdown, no more logs...
→
```
With 25s being the shutdown sleep, and 30s being logging system timeout, logs are there ✔️,
```
→ java -Dwinstone.Launcher.shutdownTimeoutSeconds=30 -jar war/target/jenkins.war
...
2025-11-03 17:02:55.648+0000 [id=52]	INFO	jenkins.InitReactorRunner$1#onAttained: Completed initialization
2025-11-03 17:02:55.687+0000 [id=26]	INFO	hudson.lifecycle.Lifecycle#onReady: Jenkins is fully up and running
^C2025-11-03 17:02:58.646+0000 [id=29]	INFO	winstone.Logger#logInternal: JVM is terminating. Shutting down Jetty
2025-11-03 17:02:58.648+0000 [id=29]	INFO	org.eclipse.jetty.server.Server#doStop: Stopped oejs.Server@566d0c69{STOPPING}[12.1.3,sto=0]
2025-11-03 17:02:58.655+0000 [id=29]	INFO	o.e.j.server.AbstractConnector#doStop: Stopped oejs.ServerConnector@49aa766b{HTTP/1.1, (http/1.1)}{0.0.0.0:8080}
Sleeping 25 seconds before shutdown...
Waking up, proceeding with shutdown, no more logs...
2025-11-03 17:03:23.666+0000 [id=29]	INFO	hudson.lifecycle.Lifecycle#onStatusUpdate: Stopping Jenkins
2025-11-03 17:03:23.707+0000 [id=29]	INFO	jenkins.model.Jenkins$17#onAttained: Started termination
2025-11-03 17:03:23.725+0000 [id=29]	INFO	jenkins.model.Jenkins$17#onAttained: Completed termination
2025-11-03 17:03:23.725+0000 [id=29]	INFO	jenkins.model.Jenkins#_cleanUpDisconnectComputers: Starting node disconnection
2025-11-03 17:03:23.728+0000 [id=29]	INFO	jenkins.model.Jenkins#_cleanUpShutdownPluginManager: Stopping plugin manager
2025-11-03 17:03:23.728+0000 [id=29]	INFO	jenkins.model.Jenkins#_cleanUpPersistQueue: Persisting build queue
2025-11-03 17:03:23.775+0000 [id=29]	INFO	jenkins.model.Jenkins#_cleanUpAwaitDisconnects: Waiting for node disconnection completion
2025-11-03 17:03:23.776+0000 [id=29]	INFO	hudson.lifecycle.Lifecycle#onStatusUpdate: Jenkins stopped
→
```
With 33s being shutdown sleep, and 30s being default logging system delay, passing arg `-Dwinstone.Launcher.loggingShutdownTimeoutSeconds=35` makes logs appear ✔️ ,
```
→ java -Dwinstone.Launcher.loggingShutdownTimeoutSeconds=35 -jar war/target/jenkins.war
...
2025-11-03 17:05:32.946+0000 [id=52]	INFO	jenkins.InitReactorRunner$1#onAttained: Completed initialization
2025-11-03 17:05:32.962+0000 [id=26]	INFO	hudson.lifecycle.Lifecycle#onReady: Jenkins is fully up and running
^C2025-11-03 17:05:34.491+0000 [id=29]	INFO	winstone.Logger#logInternal: JVM is terminating. Shutting down Jetty
2025-11-03 17:05:34.492+0000 [id=29]	INFO	org.eclipse.jetty.server.Server#doStop: Stopped oejs.Server@6f667ad1{STOPPING}[12.1.3,sto=0]
2025-11-03 17:05:34.508+0000 [id=29]	INFO	o.e.j.server.AbstractConnector#doStop: Stopped oejs.ServerConnector@45ce1e84{HTTP/1.1, (http/1.1)}{0.0.0.0:8080}
Sleeping 33 seconds before shutdown...
Waking up, proceeding with shutdown, no more logs...
2025-11-03 17:06:07.517+0000 [id=29]	INFO	hudson.lifecycle.Lifecycle#onStatusUpdate: Stopping Jenkins
2025-11-03 17:06:07.530+0000 [id=29]	INFO	jenkins.model.Jenkins$17#onAttained: Started termination
2025-11-03 17:06:07.544+0000 [id=29]	INFO	jenkins.model.Jenkins$17#onAttained: Completed termination
2025-11-03 17:06:07.544+0000 [id=29]	INFO	jenkins.model.Jenkins#_cleanUpDisconnectComputers: Starting node disconnection
2025-11-03 17:06:07.554+0000 [id=29]	INFO	jenkins.model.Jenkins#_cleanUpShutdownPluginManager: Stopping plugin manager
2025-11-03 17:06:07.556+0000 [id=29]	INFO	jenkins.model.Jenkins#_cleanUpPersistQueue: Persisting build queue
2025-11-03 17:06:07.584+0000 [id=29]	INFO	jenkins.model.Jenkins#_cleanUpAwaitDisconnects: Waiting for node disconnection completion
2025-11-03 17:06:07.584+0000 [id=29]	INFO	hudson.lifecycle.Lifecycle#onStatusUpdate: Jenkins stopped
```


### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
