### PR TITLE
Add support for H2C protocol, so client who wants to upgrade from http 1.1 to h2c can now, obviously not supported in https, (h2c is not used over SSL and HTTP/2 over TLS uses ALPN)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Other options:
    --debug                  = set the level of Winstone debug msgs (1-9). Default is 5 (INFO level)
 
    --httpPort               = set the http listening port. -1 to disable, Default is 8080
+                              Supports h2c (HTTP/2 over cleartext) via upgrade and prior knowledge
    --httpListenAddress      = set the http listening address. Default is all interfaces
    --httpUnixDomainPath     = set the http unix domain path. Default is no path
    --httpKeepAliveTimeout   = how long idle HTTP keep-alive connections are kept around (in ms; default 30000)?

--- a/src/main/java/winstone/ServerConnectorBuilder.java
+++ b/src/main/java/winstone/ServerConnectorBuilder.java
@@ -3,6 +3,7 @@ package winstone;
 import java.nio.file.Path;
 import org.eclipse.jetty.http.HttpCompliance;
 import org.eclipse.jetty.http.UriCompliance;
+import org.eclipse.jetty.http2.server.HTTP2CServerConnectionFactory;
 import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.ForwardedRequestCustomizer;
 import org.eclipse.jetty.server.HttpConfiguration;
@@ -100,9 +101,9 @@ class ServerConnectorBuilder {
 
         if (listenerUnixDomainPath != null) {
 
-            UnixDomainServerConnector usc;
-
-            usc = new UnixDomainServerConnector(server, acceptors, selectors, new HttpConnectionFactory());
+            HttpConfiguration hc = new HttpConfiguration();
+            UnixDomainServerConnector usc = new UnixDomainServerConnector(
+                    server, acceptors, selectors, new HttpConnectionFactory(hc), new HTTP2CServerConnectionFactory(hc));
 
             usc.setUnixDomainPath(Path.of(listenerUnixDomainPath));
             usc.setIdleTimeout(keepAliveTimeout);
@@ -116,7 +117,13 @@ class ServerConnectorBuilder {
             if (sslContextFactory != null) {
                 sc = new ServerConnector(server, acceptors, selectors, sslContextFactory);
             } else {
-                sc = new ServerConnector(server, acceptors, selectors);
+                HttpConfiguration hc = new HttpConfiguration();
+                sc = new ServerConnector(
+                        server,
+                        acceptors,
+                        selectors,
+                        new HttpConnectionFactory(hc),
+                        new HTTP2CServerConnectionFactory(hc));
             }
 
             sc.setPort(listenerPort);

--- a/src/main/resources/winstone/LocalStrings.properties
+++ b/src/main/resources/winstone/LocalStrings.properties
@@ -56,6 +56,7 @@ Launcher.UsageInstructions.Options=\
 \   --logThrowingThread      = show the thread that logged the message. Default is false\n\
 \   --debug                  = set the level of Winstone debug msgs (1-9). Default is 5 (INFO level)\n\n\
 \   --httpPort               = set the http listening port. -1 to disable, Default is 8080\n\
+\                              Supports h2c (HTTP/2 over cleartext) via upgrade and prior knowledge.\n\
 \   --httpListenAddress      = set the http listening address. Default is all interfaces\n\
 \   --httpUnixDomainPath     = set the http unix domain path. Default is no path\n\
 \   --httpKeepAliveTimeout   = how long idle HTTP keep-alive connections are kept around (in ms; default 30000)?\n\

--- a/src/test/java/winstone/HttpConnectorFactoryTest.java
+++ b/src/test/java/winstone/HttpConnectorFactoryTest.java
@@ -8,6 +8,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static winstone.Launcher.WINSTONE_PORT_FILE_NAME_PROPERTY;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.Socket;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -18,6 +21,10 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import org.awaitility.Awaitility;
+import org.eclipse.jetty.client.ContentResponse;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.server.LowResourceMonitor;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.unixdomain.server.UnixDomainServerConnector;
@@ -129,5 +136,69 @@ class HttpConnectorFactoryTest extends AbstractWinstoneTest {
                         "http://127.0.0.1:" + port + "/hello/"
                                 + URLEncoder.encode("win\\stone", StandardCharsets.UTF_8),
                         Protocol.HTTP_1));
+    }
+
+    @Test
+    void testH2cPriorKnowledge() throws Exception {
+        Map<String, String> args = new HashMap<>();
+        args.put("warfile", "target/test-classes/test.war");
+        args.put("prefix", "/");
+        args.put("httpPort", "0");
+        winstone = new Launcher(args);
+        int port = ((ServerConnector) winstone.server.getConnectors()[0]).getLocalPort();
+
+        HttpClient httpClient = getHttpClient();
+        ContentResponse response = httpClient
+                .newRequest("http://127.0.0.1:" + port + "/CountRequestsServlet")
+                .version(HttpVersion.HTTP_2)
+                .send();
+        httpClient.stop();
+
+        assertEquals(HttpVersion.HTTP_2, response.getVersion(), "Response should use HTTP/2");
+        assertEquals(HttpStatus.OK_200, response.getStatus());
+        assertEquals(
+                "<html><body>This servlet has been accessed via GET 1001 times</body></html>\r\n",
+                response.getContentAsString());
+    }
+
+    @Test
+    void testH2cUpgradeWithHeaders() throws Exception {
+        Map<String, String> args = new HashMap<>();
+        args.put("warfile", "target/test-classes/test.war");
+        args.put("prefix", "/");
+        args.put("httpPort", "0");
+        winstone = new Launcher(args);
+        int port = ((ServerConnector) winstone.server.getConnectors()[0]).getLocalPort();
+
+        try (Socket client = new Socket("127.0.0.1", port)) {
+            client.setSoTimeout(5000);
+            OutputStream output = client.getOutputStream();
+            output.write(("GET /CountRequestsServlet HTTP/1.1\r\n" + "Host: 127.0.0.1\r\n"
+                            + "Connection: Upgrade, HTTP2-Settings\r\n"
+                            + "Upgrade: h2c\r\n"
+                            + "HTTP2-Settings: AAEAAEAAAAIAAAABAAMAAABkAAQBAAAAAAUAAEAA\r\n"
+                            + "\r\n")
+                    .getBytes(StandardCharsets.ISO_8859_1));
+            output.flush();
+
+            InputStream input = client.getInputStream();
+            StringBuilder response = new StringBuilder();
+            int crlfs = 0;
+            while (true) {
+                int read = input.read();
+                if (read == '\r' || read == '\n') {
+                    ++crlfs;
+                } else {
+                    crlfs = 0;
+                }
+                response.append((char) read);
+                if (crlfs == 4) {
+                    break;
+                }
+            }
+            assertTrue(
+                    response.toString().startsWith("HTTP/1.1 101 "),
+                    "Expected 101 Switching Protocols but got: " + response);
+        }
     }
 }

--- a/src/test/java/winstone/HttpConnectorFactoryTest.java
+++ b/src/test/java/winstone/HttpConnectorFactoryTest.java
@@ -147,18 +147,17 @@ class HttpConnectorFactoryTest extends AbstractWinstoneTest {
         winstone = new Launcher(args);
         int port = ((ServerConnector) winstone.server.getConnectors()[0]).getLocalPort();
 
-        HttpClient httpClient = getHttpClient();
-        ContentResponse response = httpClient
-                .newRequest("http://127.0.0.1:" + port + "/CountRequestsServlet")
-                .version(HttpVersion.HTTP_2)
-                .send();
-        httpClient.stop();
-
-        assertEquals(HttpVersion.HTTP_2, response.getVersion(), "Response should use HTTP/2");
-        assertEquals(HttpStatus.OK_200, response.getStatus());
-        assertEquals(
-                "<html><body>This servlet has been accessed via GET 1001 times</body></html>\r\n",
-                response.getContentAsString());
+        try (HttpClient httpClient = getHttpClient()) {
+            ContentResponse response = httpClient
+                    .newRequest("http://127.0.0.1:" + port + "/CountRequestsServlet")
+                    .version(HttpVersion.HTTP_2)
+                    .send();
+            assertEquals(HttpVersion.HTTP_2, response.getVersion(), "Response should use HTTP/2");
+            assertEquals(HttpStatus.OK_200, response.getStatus());
+            assertEquals(
+                    "<html><body>This servlet has been accessed via GET 1001 times</body></html>\r\n",
+                    response.getContentAsString());
+        }
     }
 
     @Test
@@ -199,6 +198,14 @@ class HttpConnectorFactoryTest extends AbstractWinstoneTest {
             assertTrue(
                     response.toString().startsWith("HTTP/1.1 101 "),
                     "Expected 101 Switching Protocols but got: " + response);
+
+            assertTrue(
+                    response.toString().contains("Upgrade: h2c"),
+                    "Expected Upgrade: h2c header in response but got: " + response);
+
+            assertTrue(
+                    response.toString().contains("Connection: Upgrade"),
+                    "Expected Connection: Upgrade header in response but got: " + response);
         }
     }
 }


### PR DESCRIPTION
Signed-off-by: Olivier Lamy <olamy@apache.org>

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
