### PR TITLE
Fix symlink traversal in deleteRecursive to prevent escape from webroot

### DIFF
--- a/src/main/java/winstone/HostConfiguration.java
+++ b/src/main/java/winstone/HostConfiguration.java
@@ -229,7 +229,7 @@ public class HostConfiguration {
      */
     @SuppressFBWarnings(
             value = "PATH_TRAVERSAL_IN",
-            justification = "false positive, we're not being called from a webapp")
+            justification = "Symlinks are not followed during recursive deletion; args come from command line")
     protected File getWebRoot(File requestedWebroot, File warfile) throws IOException {
         if (warfile != null) {
             Logger.log(Level.INFO, Launcher.RESOURCES, "HostConfig.BeginningWarExtraction");
@@ -359,7 +359,18 @@ public class HostConfiguration {
         File[] children = dir.listFiles();
         if (children != null) {
             for (File child : children) {
-                deleteRecursive(child);
+                if (Files.isSymbolicLink(child.toPath())) {
+                    // Delete the symlink itself but do not follow it.
+                    // Following symlinks can escape the webroot (e.g. into /proc).
+                    try {
+                        Files.deleteIfExists(child.toPath());
+                    } catch (Exception ex) {
+                        Logger.logDirectMessage(
+                                Level.WARNING, null, "Failed to delete symlink " + child.getAbsolutePath(), ex);
+                    }
+                } else {
+                    deleteRecursive(child);
+                }
             }
         }
         try {

--- a/src/test/java/winstone/HostConfigurationTest.java
+++ b/src/test/java/winstone/HostConfigurationTest.java
@@ -1,16 +1,22 @@
 package winstone;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.NavigableMap;
 import java.util.Properties;
 import java.util.TreeMap;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.api.function.Executable;
 
 class HostConfigurationTest {
@@ -31,6 +37,36 @@ class HostConfigurationTest {
         }
 
         assertAll("Winstone MIME types must not duplicate Jetty MIME types", failures);
+    }
+
+    @Test
+    void deleteRecursiveDoesNotFollowSymlinks(@TempDir Path tempDir) throws Exception {
+        // Create a directory structure with a symlink pointing outside
+        Path webroot = tempDir.resolve("webroot");
+        Files.createDirectories(webroot);
+        Files.writeString(webroot.resolve("file.txt"), "hello");
+
+        // Create an external directory that should NOT be deleted
+        Path externalDir = tempDir.resolve("external");
+        Files.createDirectories(externalDir);
+        Files.writeString(externalDir.resolve("important.txt"), "do not delete");
+
+        // Create a symlink inside webroot pointing to the external directory
+        Path symlink = webroot.resolve("link-to-external");
+        Files.createSymbolicLink(symlink, externalDir);
+
+        // Invoke deleteRecursive via reflection since it is private
+        HostConfiguration config = null; // static context not needed, method only uses the parameter
+        Method deleteRecursive = HostConfiguration.class.getDeclaredMethod("deleteRecursive", java.io.File.class);
+        deleteRecursive.setAccessible(true);
+        deleteRecursive.invoke(config, webroot.toFile());
+
+        // The webroot should be deleted
+        assertFalse(Files.exists(webroot), "webroot should be deleted");
+
+        // The external directory should NOT be deleted (symlink was not followed)
+        assertEquals("do not delete", Files.readString(externalDir.resolve("important.txt")),
+                "external directory should not be deleted when symlink is not followed");
     }
 
     private static NavigableMap<String, String> loadMimeTypes(String name) throws IOException {


### PR DESCRIPTION
Fixes jenkinsci/jenkins#26936

### Summary

`HostConfiguration.deleteRecursive` used `File.listFiles()` which follows symbolic links. On Linux, if the webroot directory contains a symlink to `/proc/self/task/<pid>/cwd` (which itself points back to the process working directory), `deleteRecursive` would follow it and attempt to delete files outside the configured webroot, traversing into `/proc` and potentially other filesystem paths.

This was reported when a UI-driven Jenkins upgrade/restart caused `deleteRecursive` to recurse through `/proc/self/task/<pid>/cwd/...`, logging `AccessDeniedException` warnings for paths outside the webroot.

### Root Cause

`File.listFiles()` follows symlinks, and `deleteRecursive` had no check to skip them before recursing into child directories.

### Fix

Before recursing into a child in `deleteRecursive`, check `Files.isSymbolicLink()`. If the child is a symlink, delete the symlink itself but do **not** follow it. This prevents traversal outside the webroot.

Also updated the `@SuppressFBWarnings(PATH_TRAVERSAL_IN)` justification on `getWebRoot` to reflect that symlinks are no longer followed.

### Testing done

Added `deleteRecursiveDoesNotFollowSymlinks` test in `HostConfigurationTest`:
- Creates a webroot directory with a file and a symlink pointing to an external directory
- Invokes `deleteRecursive` via reflection
- Asserts the webroot is deleted
- Asserts the external directory (target of the symlink) is **not** deleted

### Screenshots (UI changes only)

N/A — No UI changes.

### Proposed changelog entries

- Fix symlink traversal in `deleteRecursive` to prevent recursive deletion from escaping the configured webroot

### Proposed changelog category

/label bug

### Proposed upgrade guidelines

N/A — The fix is a security hardening improvement; no user action required.

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate. — No new public API; existing private method behavior changed.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable. — No deprecations.
- [x] UI changes do not introduce regressions when enforcing the current default rules of Content Security Policy Plugin. — No UI changes.
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials. — No dependency updates.
- [x] For new APIs and extension points, there is a link to at least one consumer. — No new API.